### PR TITLE
resolving script path from outputDir during concatenation

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -172,12 +172,11 @@ function insertInlinedImports($, storedPosition, importText) {
   pos[operation](importText);
 }
 
-function inlineScripts(htmlstring, baseDir) {
-  if (!baseDir) baseDir = process.cwd();
+function inlineScripts(htmlstring, dir) {
   return htmlstring.replace(SCRIPT_SRC, function(match, src) {
     var out = match;
     if (!ABS_URL.test(src)) {
-      out = '<script>' + fs.readFileSync(path.resolve(baseDir, src), 'utf8') + '</script>';
+      out = '<script>' + fs.readFileSync(path.resolve(dir, src), 'utf8') + '</script>';
     }
     return out;
   });


### PR DESCRIPTION
Couple fixes:
1) Supporting inline and csp options, when output file path is not current working directory.
2) Regex for script search was not doing global match.
