### PR TITLE
fixing the use of $('style').html(cssText) to update the styles content.

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -47,11 +47,6 @@ function resolvePaths($, input, output) {
       }
     }, this);
   });
-  // resolve style elements
-  $('style').each(function() {
-    var val = this.html();
-    this.html(rewriteURL(input, output, val));
-  });
   $(ELEMENTS).each(function() {
     this.attr('assetpath', assetPath);
   });
@@ -83,13 +78,13 @@ function readDocument(docname) {
 }
 
 // inline relative linked stylesheets into <style> tags
-function inlineSheets($, dir) {
+function inlineSheets($, inputPath, outputPath) {
   $('link[rel="stylesheet"]').each(function() {
     var href = this.attr('href');
     if (href && !ABS_URL.test(href)) {
-      var filepath = path.resolve(dir, href);
-      // fix up paths in the stylesheet to be relative to this import
-      var content = rewriteURL(path.dirname(filepath), dir, fs.readFileSync(filepath, 'utf8'));
+      var filepath = path.resolve(inputPath, href);
+      // fix up paths in the stylesheet to be relative to the output path
+      var content = rewriteURL(path.dirname(filepath), outputPath, fs.readFileSync(filepath, 'utf8'));
       var styleDoc = cheerio.load('<style>' + content + '</style>');
       var polymerScope = this.attr('polymer-scope');
       if (polymerScope) {
@@ -106,7 +101,7 @@ function concat(filename) {
     var $ = readDocument(filename);
     var dir = path.dirname(filename);
     processImports($, dir);
-    inlineSheets($, dir);
+    inlineSheets($, dir, options.outputDir);
     resolvePaths($, dir, options.outputDir);
     import_buffer.push($.html());
   } else {


### PR DESCRIPTION
Removed the use of .html(cssText) as it was treating any html tags in cssText, eg. in comments etc., as DOM nodes and messing up the stylesheets.
