### PR TITLE
Add excluded script instead of its contents

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -298,7 +298,7 @@ function handleMainDocument() {
         // external script
         if (excludeScript(src)) {
           // put an absolute path script after polymer.js in main document
-          scripts_after_polymer.push(this.html());
+          scripts_after_polymer.push(this.toString());
         } else {
           scripts.push(fs.readFileSync(path.resolve(options.outputDir, src), 'utf8'));
         }


### PR DESCRIPTION
this.html() returns <script> tag's inner html, but we want to add the entire tag.
