### PR TITLE
Workaround for stripping comments in head tag

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -160,6 +160,7 @@ function removeCommentsAndWhitespace($) {
     setTextContent(el, new cleancss({noAdvanced: true}).minify(content));
   });
   $('head').contents().filter(isCommentOrEmptyTextNode).remove();
+  $('head div').contents().filter(isCommentOrEmptyTextNode).remove();
   $('body').contents().filter(isCommentOrEmptyTextNode).remove();
   $.root().contents().filter(isCommentOrEmptyTextNode).remove();
 }


### PR DESCRIPTION
Currently comments inside `head > div` are not filtered by cheerio. Simple workaround is to add filter for `head div` query.
