### PR TITLE
converted vulcanize to stdio-when-needed library and utility

### DIFF
--- a/bin/vulcanize
+++ b/bin/vulcanize
@@ -2,7 +2,6 @@
 var path = require('path');
 var fs = require('fs');
 var nopt = require('nopt');
-var vulcan = require('../lib/vulcan.js');
 
 var help = [
   'vulcanize: Concatenate a set of Web Components into one file',
@@ -15,6 +14,7 @@ var help = [
   '  --verbose, -v: More verbose logging',
   '  --help, -h, -?: Print this message',
   '  --config: Read the given config file',
+  '  --stdio: Read input from stdin and output to stdio',
   '  --strip, -s: Remove comments and empty text nodes',
   '  --csp: Extract inline scripts to a separate file (uses <output file name>.js)',
   '  --inline: The opposite of CSP mode, inline all assets (script and css) into the document',
@@ -44,6 +44,7 @@ var options = nopt(
     'help': Boolean,
     'inline': Boolean,
     'output': path,
+    'stdio': Boolean,
     'strip': Boolean,
     'verbose': Boolean
   },
@@ -51,6 +52,7 @@ var options = nopt(
     '?': ['--help'],
     'h': ['--help'],
     'o': ['--output'],
+    'i': ['--stdio'],
     's': ['--strip'],
     'v': ['--verbose']
   }
@@ -66,10 +68,29 @@ if (argv[0]) {
   options.input = path.resolve(argv[0]);
 }
 
-vulcan.setOptions(options, function(err) {
-  if (err) {
-    console.error(err);
-    process.exit(1);
-  }
-  vulcan.processDocument();
-});
+var vulcan = new require('../lib/vulcan.js');
+
+/**
+ * vulcanize can be called either as autonomous process,
+ * reading and writing from/to file, or as piped utility,
+ * accepting input from stdin and sending output to stdout.
+ */
+function vulcanize(input) {
+  vulcan.process(input, options, function(err, data) {
+    if (err) {
+      console.error(err);
+      process.exit(1);
+    }
+    if (options.stdio) {
+      process.stdout.write(data);
+    }
+  });
+}
+
+if (!options.input && options.stdio) {
+  var aggregate = '';
+  process.stdin.resume();
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', function(data) { aggregate += data; });
+  process.stdin.on('end', function() { vulcanize(aggregate); });
+} else { vulcanize(false); }

--- a/lib/optparser.js
+++ b/lib/optparser.js
@@ -35,7 +35,7 @@ function processOptions(options, callback) {
   }
 
   options.input = options.input || config.input;
-  if (!options.input) {
+  if (!options.input && !options.stdio) {
     return callback('No input file given!');
   }
 

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -3,7 +3,6 @@
  * Use of this source code is governed by a BSD-style
  * license that can be found in the LICENSE file.
  */
-
 var cheerio = require('cheerio');
 var cleancss = require('clean-css');
 var fs = require('fs');
@@ -18,252 +17,291 @@ var utils = require('./utils');
 var setTextContent = utils.setTextContent;
 var getTextContent = utils.getTextContent;
 
-var read = {};
-var options = {};
+/**
+ * The vulcaniser wraps a full processing environment.
+ */
+function Vulcanizer() {
+  var read = {};
+  var options = {};
 
-// validate options with boolean return
-function setOptions(optHash, callback) {
-  optparser.processOptions(optHash, function(err, o) {
-    if (err) {
-      return callback(err);
-    }
-    options = o;
-    callback();
-  });
-}
-
-function exclude(regexes, href) {
-  return regexes.some(function(r) {
-    return r.test(href);
-  });
-}
-
-function excludeImport(href) {
-  return exclude(options.excludes.imports, href);
-}
-
-function excludeScript(href) {
-  return exclude(options.excludes.scripts, href);
-}
-
-function excludeStyle(href) {
-  return exclude(options.excludes.styles, href);
-}
-
-function readFile(file) {
-  var content = fs.readFileSync(file, 'utf8');
-  return content.replace(/^\uFEFF/, '');
-}
-
-// inline relative linked stylesheets into <style> tags
-function inlineSheets($, inputPath, outputPath) {
-  $('link[rel="stylesheet"]').each(function() {
-    var el = $(this);
-    var href = el.attr('href');
-    if (href && !excludeStyle(href)) {
-      var filepath = path.resolve(options.outputDir, href);
-      // fix up paths in the stylesheet to be relative to the location of the style
-      var content = pathresolver.rewriteURL(path.dirname(filepath), outputPath, readFile(filepath));
-      var styleDoc = cheerio.load('<style>' + content + '</style>');
-      // clone attributes
-      styleDoc('style').attr(el.attr());
-      // don't set href or rel on the <style>
-      styleDoc('style').attr('href', null);
-      styleDoc('style').attr('rel', null);
-      el.replaceWith(styleDoc.html());
-    }
-  });
-}
-
-function inlineScripts($, dir) {
-  $(constants.JS_SRC).each(function() {
-    var el = $(this);
-    var src = el.attr('src');
-    if (src && !excludeScript(src)) {
-      var filepath = path.resolve(dir, src);
-      var content = readFile(filepath);
-      // NOTE: reusing UglifyJS's inline script printer (not exported from OutputStream :/)
-      content = content.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
-      el.replaceWith('<script>' + content + '</script>');
-    }
-  });
-}
-
-function readDocument(filename) {
-  return cheerio.load(readFile(filename));
-}
-
-function concat(filename) {
-  if (!read[filename]) {
-    read[filename] = true;
-    var $ = readDocument(filename);
-    var dir = path.dirname(filename);
-    pathresolver.resolvePaths($, dir, options.outputDir);
-    processImports($);
-    inlineSheets($, dir, options.outputDir);
-    return $.html();
-  } else {
-    if (options.verbose) {
-      console.log('Dependency deduplicated');
-    }
-  }
-}
-
-function processImports($, mainDoc) {
-  $(constants.IMPORTS).each(function() {
-    var el = $(this);
-    var href = el.attr('href');
-    if (!excludeImport(href)) {
-      var importContent = concat(path.resolve(options.outputDir, href));
-      // hide import content in the main document
-      if (mainDoc) {
-        importContent = '<div hidden>' + importContent + '</div>';
+  // validate options with boolean return
+  this.setOptions = function setOptions(optHash, callback) {
+    optparser.processOptions(optHash, function(err, o) {
+      if (err) {
+        return callback(err);
       }
-      el.replaceWith(importContent);
+      options = o;
+      callback();
+    });
+  };
+
+  function exclude(regexes, href) {
+    return regexes.some(function(r) {
+      return r.test(href);
+    });
+  }
+
+  function excludeImport(href) {
+    return exclude(options.excludes.imports, href);
+  }
+
+  function excludeScript(href) {
+    return exclude(options.excludes.scripts, href);
+  }
+
+  function excludeStyle(href) {
+    return exclude(options.excludes.styles, href);
+  }
+
+  function readFile(file) {
+    var content = fs.readFileSync(file, 'utf8');
+    return content.replace(/^\uFEFF/, '');
+  }
+
+  // inline relative linked stylesheets into <style> tags
+  function inlineSheets($, inputPath, outputPath) {
+    $('link[rel="stylesheet"]').each(function() {
+      var el = $(this);
+      var href = el.attr('href');
+      if (href && !excludeStyle(href)) {
+        var filepath = path.resolve(options.outputDir, href);
+        // fix up paths in the stylesheet to be relative to the location of the style
+        var content = pathresolver.rewriteURL(path.dirname(filepath), outputPath, readFile(filepath));
+        var styleDoc = cheerio.load('<style>' + content + '</style>');
+        // clone attributes
+        styleDoc('style').attr(el.attr());
+        // don't set href or rel on the <style>
+        styleDoc('style').attr('href', null);
+        styleDoc('style').attr('rel', null);
+        el.replaceWith(styleDoc.html());
+      }
+    });
+  }
+
+  function inlineScripts($, dir) {
+    $(constants.JS_SRC).each(function() {
+      var el = $(this);
+      var src = el.attr('src');
+      if (src && !excludeScript(src)) {
+        var filepath = path.resolve(dir, src);
+        var content = readFile(filepath);
+        // NOTE: reusing UglifyJS's inline script printer (not exported from OutputStream :/)
+        content = content.replace(/<\x2fscript([>\/\t\n\f\r ])/gi, "<\\/script$1");
+        el.replaceWith('<script>' + content + '</script>');
+      }
+    });
+  }
+
+  function interpret(filedata) {
+    return cheerio.load(filedata);
+  }
+
+  function readDocument(filename) {
+    return interpret(readFile(filename));
+  }
+
+  function concat(filename) {
+    if (!read[filename]) {
+      read[filename] = true;
+      var $ = readDocument(filename);
+      var dir = path.dirname(filename);
+      pathresolver.resolvePaths($, dir, options.outputDir);
+      processImports($);
+      inlineSheets($, dir, options.outputDir);
+      return $.html();
+    } else {
+      if (options.verbose) {
+        console.log('Dependency deduplicated');
+      }
     }
-  });
-}
-
-function findScriptLocation($) {
-  var pos = $('body').last();
-  if (!pos.length) {
-    pos = $.root();
-  }
-  return pos;
-}
-
-// arguments are (index, node), where index is unnecessary
-function isCommentOrEmptyTextNode(_, node) {
-  if (node.type === 'comment'){
-    return true;
-  } else if (node.type === 'text') {
-    // return true if the node is only whitespace
-    return !((/\S/).test(node.data));
-  }
-}
-
-function compressJS(content, inline) {
-  var ast = uglify.parse(content);
-  return ast.print_to_string({inline_script: inline});
-}
-
-function removeCommentsAndWhitespace($) {
-  $(constants.JS_INLINE).each(function() {
-    var el = $(this);
-    var content = getTextContent(el);
-    setTextContent(el, compressJS(content, true));
-  });
-  $(constants.CSS).each(function() {
-    var el = $(this);
-    var content = getTextContent(el);
-    setTextContent(el, new cleancss({noAdvanced: true}).minify(content));
-  });
-  $('head').contents().filter(isCommentOrEmptyTextNode).remove();
-  $('body').contents().filter(isCommentOrEmptyTextNode).remove();
-  $.root().contents().filter(isCommentOrEmptyTextNode).remove();
-}
-
-function handleMainDocument() {
-  // reset shared buffers
-  read = {};
-  var $ = readDocument(options.input);
-  var dir = path.dirname(options.input);
-  pathresolver.resolvePaths($, dir, options.outputDir);
-  processImports($, true);
-  if (options.inline) {
-    inlineSheets($, dir, options.outputDir);
   }
 
-  if (options.inline) {
-    inlineScripts($, options.outputDir);
-  }
-
-  $(constants.JS_INLINE).each(function() {
-    var el = $(this);
-    var content = getTextContent(el);
-    // find ancestor polymer-element node
-    var parentElement = el.closest('polymer-element').get(0);
-    if (parentElement) {
-      var match = constants.POLYMER_INVOCATION.exec(content);
-      // skip Polymer() calls that have the tag name
-      if (match && !match[1]) {
-        // get element name
-        var name = $(parentElement).attr('name');
-        // build the named Polymer invocation
-        var namedInvocation = 'Polymer(\'' + name + '\'' + (match[2] === '{' ? ',{' : ')');
-        content = content.replace(match[0], namedInvocation);
-        if (options.verbose) {
-          console.log(match[0], '->', namedInvocation);
+  function processImports($, mainDoc) {
+    $(constants.IMPORTS).each(function() {
+      var el = $(this);
+      var href = el.attr('href');
+      if (!excludeImport(href)) {
+        var importContent = concat(path.resolve(options.outputDir, href));
+        // hide import content in the main document
+        if (mainDoc) {
+          importContent = '<div hidden>' + importContent + '</div>';
         }
-        setTextContent(el, content);
+        el.replaceWith(importContent);
       }
-    }
-  });
+    });
+  }
 
-  // strip noscript from elements, and instead inject explicit Polymer() invocation
-  // script, so registration order is preserved
-  $(constants.ELEMENTS_NOSCRIPT).each(function() {
-    var el = $(this);
-    var name = el.attr('name');
-    if (options.verbose) {
-      console.log('Injecting explicit Polymer invocation for noscript element "' + name + '"');
+  function findScriptLocation($) {
+    var pos = $('body').last();
+    if (!pos.length) {
+      pos = $.root();
     }
-    el.append('<script>Polymer(\'' + name + '\');</script>');
-    el.attr('noscript', null);
-  });
+    return pos;
+  }
 
-  // strip scripts into a separate file
-  if (options.csp) {
-    if (options.verbose) {
-      console.log('Separating scripts into separate file');
+  // arguments are (index, node), where index is unnecessary
+  function isCommentOrEmptyTextNode(_, node) {
+    if (node.type === 'comment'){
+      return true;
+    } else if (node.type === 'text') {
+      // return true if the node is only whitespace
+      return !((/\S/).test(node.data));
     }
+  }
 
-    // CSPify main page by removing inline scripts
-    var scripts = [];
+  function compressJS(content, inline) {
+    var ast = uglify.parse(content);
+    return ast.print_to_string({inline_script: inline});
+  }
+
+  function removeCommentsAndWhitespace($) {
     $(constants.JS_INLINE).each(function() {
       var el = $(this);
       var content = getTextContent(el);
-      scripts.push(content);
-      el.remove();
+      setTextContent(el, compressJS(content, true));
+    });
+    $(constants.CSS).each(function() {
+      var el = $(this);
+      var content = getTextContent(el);
+      setTextContent(el, new cleancss({noAdvanced: true}).minify(content));
+    });
+    $('head').contents().filter(isCommentOrEmptyTextNode).remove();
+    $('body').contents().filter(isCommentOrEmptyTextNode).remove();
+    $.root().contents().filter(isCommentOrEmptyTextNode).remove();
+  }
+
+  function deduplicateImports($) {
+    var imports = {};
+    $(constants.IMPORTS).each(function() {
+      var el = $(this);
+      var href = el.attr('href');
+      // TODO(dfreedm): allow a user defined base url?
+      var abs = url.resolve('http://', href);
+      if (!imports[abs]) {
+        imports[abs] = true;
+      } else {
+        if(options.verbose) {
+          console.log('Import Dependency deduplicated');
+        }
+        el.remove();
+      }
+    });
+  }
+
+  /**
+   * The function where everything happens.
+   */
+  this.handleMainDocument = function handleMainDocument(input, callback) {
+    // reset shared buffers
+    read = {};
+    // do we have input data, or do we read from options.input file?
+    if(typeof input === "function") {
+      callback = input;
+      input = false;
+    }
+    var $ = input ? interpret(input) : readDocument(options.input);
+    var dir = input ? "." : path.dirname(options.input);
+    pathresolver.resolvePaths($, dir, options.outputDir);
+    processImports($, true);
+    if (options.inline) {
+      inlineSheets($, dir, options.outputDir);
+    }
+
+    if (options.inline) {
+      inlineScripts($, options.outputDir);
+    }
+
+    $(constants.JS_INLINE).each(function() {
+      var el = $(this);
+      var content = getTextContent(el);
+      // find ancestor polymer-element node
+      var parentElement = el.closest('polymer-element').get(0);
+      if (parentElement) {
+        var match = constants.POLYMER_INVOCATION.exec(content);
+        // skip Polymer() calls that have the tag name
+        if (match && !match[1]) {
+          // get element name
+          var name = $(parentElement).attr('name');
+          // build the named Polymer invocation
+          var namedInvocation = 'Polymer(\'' + name + '\'' + (match[2] === '{' ? ',{' : ')');
+          content = content.replace(match[0], namedInvocation);
+          if (options.verbose) {
+            console.log(match[0], '->', namedInvocation);
+          }
+          setTextContent(el, content);
+        }
+      }
     });
 
-    // join scripts with ';' to prevent breakages due to EOF semicolon insertion
-    var scriptName = path.basename(options.output, '.html') + '.js';
-    var scriptContent = scripts.join(';' + constants.EOL);
-    if (options.strip) {
-      scriptContent = compressJS(scriptContent, false);
-    }
-    fs.writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent, 'utf8');
-    // insert out-of-lined script into document
-    findScriptLocation($).append('<script src="' + scriptName + '"></script>');
-  }
-
-  deduplicateImports($);
-
-  if (options.strip) {
-    removeCommentsAndWhitespace($);
-  }
-  var outhtml = $.html();
-  fs.writeFileSync(options.output, outhtml, 'utf8');
-}
-
-function deduplicateImports($) {
-  var imports = {};
-  $(constants.IMPORTS).each(function() {
-    var el = $(this);
-    var href = el.attr('href');
-    // TODO(dfreedm): allow a user defined base url?
-    var abs = url.resolve('http://', href);
-    if (!imports[abs]) {
-      imports[abs] = true;
-    } else {
-      if(options.verbose) {
-        console.log('Import Dependency deduplicated');
+    // strip noscript from elements, and instead inject explicit Polymer() invocation
+    // script, so registration order is preserved
+    $(constants.ELEMENTS_NOSCRIPT).each(function() {
+      var el = $(this);
+      var name = el.attr('name');
+      if (options.verbose) {
+        console.log('Injecting explicit Polymer invocation for noscript element "' + name + '"');
       }
-      el.remove();
-    }
-  });
-}
+      el.append('<script>Polymer(\'' + name + '\');</script>');
+      el.attr('noscript', null);
+    });
 
-exports.processDocument = handleMainDocument;
-exports.setOptions = setOptions;
+    // strip scripts into a separate file
+    if (options.csp) {
+      if (options.verbose) {
+        console.log('Separating scripts into separate file');
+      }
+
+      // CSPify main page by removing inline scripts
+      var scripts = [];
+      $(constants.JS_INLINE).each(function() {
+        var el = $(this);
+        var content = getTextContent(el);
+        scripts.push(content);
+        el.remove();
+      });
+
+      // join scripts with ';' to prevent breakages due to EOF semicolon insertion
+      var scriptName = path.basename(options.output, '.html') + '.js';
+      var scriptContent = scripts.join(';' + constants.EOL);
+      if (options.strip) {
+        scriptContent = compressJS(scriptContent, false);
+      }
+      fs.writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent, 'utf8');
+      // insert out-of-lined script into document
+      findScriptLocation($).append('<script src="' + scriptName + '"></script>');
+    }
+    deduplicateImports($);
+    if (options.strip) {
+      removeCommentsAndWhitespace($);
+    }
+    var outhtml = $.html();
+    if (!options.stdio) {
+      fs.writeFileSync(options.output, outhtml, 'utf8');
+    }
+    if (callback) {
+      callback(false, outhtml);
+    }
+  };
+};
+
+/**
+ * export a single function that allows vulcanization runs
+ * based on the passed options object. If no options are
+ * passed,
+ */
+exports.process = function(input, options, callback) {
+  var vulcanizer = new Vulcanizer();
+  if (typeof options === "function") {
+    callback = options;
+    options = {
+      stdio: true,
+      inline: true
+    };
+  }
+  vulcanizer.setOptions(options, function(err) {
+    if(err) {
+      return callback(err);
+    }
+    vulcanizer.handleMainDocument(input, callback);
+  });
+};

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
   },
   "bugs": {
     "url": "https://github.com/Polymer/vulcanize/issues"
+  },
+  "scripts": {
+    "test": "node test.js"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,0 +1,16 @@
+/**
+ * Simple stdio vulcanize test. Loads the import test
+ * file and tries to fully resolve it. If this fails,
+ * the process will exit with a non-zero error code.
+ */
+var vulcan = require('./lib/vulcan.js');
+var fs = require('fs');
+process.chdir('test');
+var data = fs.readFileSync('./import-test.html').toString();
+vulcan.process(data, function(err, data) {
+	if(err) {
+		console.error(err);
+		process.exit(1);
+	}
+	console.log(data);
+});

--- a/test/import-test.html
+++ b/test/import-test.html
@@ -1,4 +1,3 @@
-<link rel="import" href="bower_components/polymer/polymer.html">
 <link rel="import" href="sub-import/sub-import.html">
 <polymer-element name="x-import">
   <template>

--- a/test/sub-import/sub-import.html
+++ b/test/sub-import/sub-import.html
@@ -1,4 +1,3 @@
-<link rel="import" href="../bower_components/polymer/polymer.html">
 <polymer-element name="y-import">
   <template>
     <style>


### PR DESCRIPTION
fixes #46, fixes #48 

This patch wraps the vulcan.js code as an object so that its processing environment is local to single object instances, with a `process` function that either works off of the `options.input` and `options.output` when used, or from standard I/O when `options.stdio` is used, allowing it to be used as a piping utility (e.g. `ls *.html | vulcanise --stdio | ...`) as well as "just another step" libary in node.js itself through:

```
var vulcan = require('vulcanize');
var data = "...";
vulcan.process(data, function(err, data) {
  if(err) { console.error(err); }
  // do something with vulcanised [data]
});
```

Note that the new indentation because of object wrapping is going to make the changes look far more substantial than they really are. [removing whitespace from the diff view using ?w=1](https://github.com/Polymer/vulcanize/pull/49/files?w=1) is going to show the actual patch without whitespace interference.
