### PR TITLE
Add quotes around filenames in CSS

### DIFF
--- a/lib/pathresolver.js
+++ b/lib/pathresolver.js
@@ -55,7 +55,7 @@ function rewriteURL(inputPath, outputPath, cssText) {
   return cssText.replace(constants.URL, function(match) {
     var path = match.replace(/["']/g, "").slice(4, -1);
     path = rewriteRelPath(inputPath, outputPath, path);
-    return 'url(' + path + ')';
+    return 'url("' + path + '")';
   });
 }
 


### PR DESCRIPTION
Some browsers (including Chrome) fail to handle filepaths with spaces unless they are quoted.
