### PR TITLE
Fixed missing use of CHEERIO_OPTIONS after merging #59

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -113,7 +113,7 @@ function concat(filename) {
     inlineSheets($, dir, options.outputDir);
     // NOTE: work-around dom-serializer
     // return $.html();
-    return render($._root.children, cheerio.prototype.options);
+    return render($._root.children, CHEERIO_OPTIONS);
   } else {
     if (options.verbose) {
       console.log('Dependency deduplicated');


### PR DESCRIPTION
#59 was missed a replacement of cheerio.prototype.options on one of the render calls in vulcan.js
