### PR TITLE
Support buffer in/out

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -99,14 +99,10 @@ function inlineScripts($, dir) {
   });
 }
 
-function readDocument(filename) {
-  return cheerio.load(readFile(filename), CHEERIO_OPTIONS);
-}
-
 function concat(filename) {
   if (!read[filename]) {
     read[filename] = true;
-    var $ = readDocument(filename);
+    var $ = cheerio.load(readFile(filename), CHEERIO_OPTIONS);
     var dir = path.dirname(filename);
     pathresolver.resolvePaths($, dir, options.outputDir);
     processImports($);
@@ -174,10 +170,19 @@ function removeCommentsAndWhitespace($) {
   $('*').contents().filter(isCommentOrEmptyTextNode).remove();
 }
 
+function writeFileSync(filename, data, eof) {
+  if (!options.outputSrc) {
+    fs.writeFileSync(filename, data, 'utf8');
+  } else {
+    options.outputSrc(filename, data, eof);
+  }
+}
+
 function handleMainDocument() {
   // reset shared buffers
   read = {};
-  var $ = readDocument(options.input);
+  var content = options.inputSrc ? readFile(options.input) : options.inputSrc.toString();
+  var $ = cheerio.load(content, CHEERIO_OPTIONS);
   var dir = path.dirname(options.input);
   pathresolver.resolvePaths($, dir, options.outputDir);
   processImports($, true);
@@ -244,7 +249,7 @@ function handleMainDocument() {
     if (options.strip) {
       scriptContent = compressJS(scriptContent, false);
     }
-    fs.writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent, 'utf8');
+    writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent);
     // insert out-of-lined script into document
     findScriptLocation($).append('<script src="' + scriptName + '"></script>');
   }
@@ -255,8 +260,7 @@ function handleMainDocument() {
     removeCommentsAndWhitespace($);
   }
 
-  var outhtml = render($._root.children, CHEERIO_OPTIONS);
-  fs.writeFileSync(options.output, outhtml, 'utf8');
+  writeFileSync(options.output, render($._root.children, CHEERIO_OPTIONS), true);
 }
 
 function deduplicateImports($) {


### PR DESCRIPTION
Refer https://github.com/Polymer/vulcanize/issues/7 

I have added simple patches to make vulcanize supports buffer in/out. I have tried to change the minimum as possible. I don't want make a noise because of this PR. I had test with my gulp-vulcanize branch. [1](https://github.com/ragingwind/gulp-vulcanize/blob/vulcanize-with-buffer/index.js) I added two more options, inputSrc(Buffer from gulp.src) and outputSrc(callback). If vulcanize supports buffer and gulp-vulcanize supports stream, I could use rename, uglify and htmlmin task at outside like below

```
return gulp.src('src/index.html')
      .pipe(vulcanize({
        dest: configs.output.debug,
        csp: true,
        excludes: {
          imports: [
            'polymer.html'
          ]
        }
      }))
      .pipe(rename(function (path) {
        if (path.extname === '.html') {
          path.basename = 'index-vulcanized'
        }
      }))
      .pipe(gulpif('*.js', uglify()))
      .pipe(gulpif('*.html', htmlmin({
        collapseWhitespace: true,
        removeComments: true,
        minifyCSS: true,
        minifyJS: true,
        customAttrAssign: [/\?=/]
      })))
      .pipe(gulp.dest(configs.output.debug));
```

I need your thought on this.
