### PR TITLE
undefined element when processing polymer invocations

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -226,6 +226,7 @@ function handleMainDocument() {
     var parentElement = el.closest('polymer-element').get(0);
     if (parentElement) {
       var match = constants.POLYMER_INVOCATION.exec(content);
+      var elementName = $(parentElement).attr('name');
       if (match) {
         var invocation = utils.processPolymerInvocation(elementName, match);
         content.replace(match[0], invocation);


### PR DESCRIPTION
Hi,

Trying to vulcanize and running into this error.

```
        var invocation = utils.processPolymerInvocation(elementName, match);
                                                        ^
ReferenceError: elementName is not defined
    at Object.<anonymous> (/Users/foo/git/vulcanize/lib/vulcan.js:230:57)
    at exports.each (/Users/foo/git/vulcanize/node_modules/whacko/lib/api/traversing.js:294:24)
    at Object.handleMainDocument [as processDocument] (/Users/foo/git/vulcanize/lib/vulcan.js:222:26)
    at /Users/foo/git/vulcanize/bin/vulcanize:109:10
    at /Users/foo/git/vulcanize/lib/vulcan.js:33:5
    at Object.processOptions (/Users/foo/git/vulcanize/lib/optparser.js:92:3)
    at Object.setOptions (/Users/foo/git/vulcanize/lib/vulcan.js:28:13)
    at Object.<anonymous> (/Users/foo/git/vulcanize/bin/vulcanize:104:8)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
```

Originated here: https://github.com/Polymer/vulcanize/commit/7d5256fa6dfbc276e3f9cfabdd9d483a4f5f3f3f#diff-2fd25663c1d3dca2153ce60dac0f7245R225

Thank you,

Jon
