### PR TITLE
Support for mobile URL Schemes "tel:" and "sms:"

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -15,7 +15,7 @@ module.exports = {
   EOL: require('os').EOL,
   ELEMENTS: 'polymer-element:not([assetpath])',
   ELEMENTS_NOSCRIPT: 'polymer-element[noscript]',
-  ABS_URL: /(^data:)|(^http[s]?:)|(^\/)|(^mailto:)/,
+  ABS_URL: /(^data:)|(^http[s]?:)|(^\/)|(^mailto:)|(^tel:)|(^sms:)/,
   REMOTE_ABS_URL: /(^http[s]?\:)|(^\/\/)/,
   IMPORTS: 'link[rel="import"][href]',
   URL: /url\([^)]*\)/g,

--- a/test/test.js
+++ b/test/test.js
@@ -25,6 +25,8 @@ suite('constants', function() {
       assert(abs.test('http://foo.com'), 'http');
       assert(abs.test('https://foo.com'), 'https');
       assert(abs.test('mailto:foo@bar.com'), 'mailto');
+      assert(abs.test('tel:+49123123456'), 'phonecall');
+      assert(abs.test('sms:1-123-123456'), 'sms');
       assert(abs.test('//foo.com'), 'protocol-free');
       assert(abs.test('/components/'), '/');
       assert(!abs.test('../foo/bar.html'), '../');


### PR DESCRIPTION
Hi,

in my opinion it should be possible for vulcanize to detect `tel:` and `sms:` URL Schemes as well beside the current `data:` and `mailto:` Schemes.

``` html
<a href="tel:+49123123456">Make a call</a>
<a href="sms:1-123-123456">Write SMS</a>
```
