### PR TITLE
Add charset=utf-8 to the resulting script tag of vulcanize to avoid brok...

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -291,7 +291,7 @@ function handleMainDocument() {
 
     writeFileSync(path.resolve(options.outputDir, scriptName), scriptContent);
     // insert out-of-lined script into document
-    findScriptLocation($).append('<script src="' + scriptName + '"></script>');
+    findScriptLocation($).append('<script charset="utf-8" src="' + scriptName + '"></script>');
   }
 
   deduplicateImports($);


### PR DESCRIPTION
...en encoding of valid utf-8 generated by uglifyjs
