### PR TITLE
automatic lazy bundle support

### DIFF
--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -236,7 +236,7 @@ function documentCollectionToManifestJson(documents: DocumentCollection):
     console.log(err);
     return;
   }
-  if (bundles.size > 1) {
+  if (bundles.size > 1 || options['out-dir']) {
     const outDir = options['out-dir'];
     if (!outDir) {
       throw new Error(

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -164,7 +164,6 @@ export function generateSharedDepsMergeStrategy(minEntrypoints: number):
     const newBundles: Bundle[] = [];
     const sharedBundles: Bundle[] = [];
     const allEntrypoints = new Set<UrlString>();
-    console.log(bundles);
     for (const bundle of bundles) {
       bundle.entrypoints.forEach(
           (entrypoint) => allEntrypoints.add(entrypoint));

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -164,6 +164,7 @@ export function generateSharedDepsMergeStrategy(minEntrypoints: number):
     const newBundles: Bundle[] = [];
     const sharedBundles: Bundle[] = [];
     const allEntrypoints = new Set<UrlString>();
+    console.log(bundles);
     for (const bundle of bundles) {
       bundle.entrypoints.forEach(
           (entrypoint) => allEntrypoints.add(entrypoint));

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -467,24 +467,6 @@ class Bundler {
       mapper?: BundleUrlMapper): Promise<DocumentCollection> {
     const bundledDocuments: DocumentCollection =
         new Map<string, BundledDocument>();
-    if (entrypoints.length === 1) {
-      const url = entrypoints[0];
-      const depsIndex = await buildDepsIndex(entrypoints, this.analyzer);
-      const bundles = generateBundles(depsIndex.entrypointToDeps);
-      for (const exclude of this.excludes) {
-        bundles[0].files.delete(exclude);
-      }
-      const manifest =
-          new BundleManifest(bundles, () => new Map([[url, bundles[0]]]));
-      const bundle = {
-        url: url,
-        bundle: bundles[0],
-      };
-      const doc = await this._bundleDocument(bundle, manifest);
-      bundledDocuments.set(
-          url, {ast: doc, files: Array.from(bundles[0].files)});
-      return bundledDocuments;
-    } else {
       const bundles = new Map<string, ASTNode>();
       if (!strategy) {
         strategy = generateSharedDepsMergeStrategy(2);
@@ -506,7 +488,6 @@ class Bundler {
             {ast: bundledAst, files: Array.from(bundle.bundle.files)});
       }
       return bundledDocuments;
-    }
   }
 
   /**

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -467,27 +467,26 @@ class Bundler {
       mapper?: BundleUrlMapper): Promise<DocumentCollection> {
     const bundledDocuments: DocumentCollection =
         new Map<string, BundledDocument>();
-      const bundles = new Map<string, ASTNode>();
-      if (!strategy) {
-        strategy = generateSharedDepsMergeStrategy(2);
-      }
-      if (!mapper) {
-        mapper = sharedBundleUrlMapper;
-      }
-      const index = await buildDepsIndex(entrypoints, this.analyzer);
-      const basicBundles = generateBundles(index.entrypointToDeps);
-      const bundlesAfterStrategy = strategy(basicBundles);
-      const manifest = new BundleManifest(bundlesAfterStrategy, mapper);
-      for (const bundleEntry of manifest.bundles) {
-        const bundleUrl = bundleEntry[0];
-        const bundle = {url: bundleUrl, bundle: bundleEntry[1]};
-        const bundledAst =
-            await this._bundleDocument(bundle, manifest, bundle.bundle.files);
-        bundledDocuments.set(
-            bundleUrl,
-            {ast: bundledAst, files: Array.from(bundle.bundle.files)});
-      }
-      return bundledDocuments;
+    const bundles = new Map<string, ASTNode>();
+    if (!strategy) {
+      strategy = generateSharedDepsMergeStrategy(2);
+    }
+    if (!mapper) {
+      mapper = sharedBundleUrlMapper;
+    }
+    const index = await buildDepsIndex(entrypoints, this.analyzer);
+    const basicBundles = generateBundles(index.entrypointToDeps);
+    const bundlesAfterStrategy = strategy(basicBundles);
+    const manifest = new BundleManifest(bundlesAfterStrategy, mapper);
+    for (const bundleEntry of manifest.bundles) {
+      const bundleUrl = bundleEntry[0];
+      const bundle = {url: bundleUrl, bundle: bundleEntry[1]};
+      const bundledAst =
+          await this._bundleDocument(bundle, manifest, bundle.bundle.files);
+      bundledDocuments.set(
+          bundleUrl, {ast: bundledAst, files: Array.from(bundle.bundle.files)});
+    }
+    return bundledDocuments;
   }
 
   /**

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -37,6 +37,8 @@ async function _getTransitiveDependencies(
       const eagerImports = new Set<string>();
       const lazyImports = new Set<string>();
       const entrypointSet = new Set(entrypoints);
+      const urls: [string, string][] = [];
+      imports.forEach((value) => urls.push([value.type, value.url]));
       for (let htmlImport of imports) {
         try {
           console.assert(
@@ -73,7 +75,6 @@ export async function buildDepsIndex(entrypoints: string[], analyzer: Analyzer):
         }
         const dependencyEntry =
             await _getTransitiveDependencies(entrypoint, entrypoints, analyzer);
-        debugger;
         const dependencies = new Set(dependencyEntry.eager);
         dependencies.add(entrypoint);
         entrypointToDependencies.set(entrypoint, dependencies);


### PR DESCRIPTION
Add the ability for vulcanize to determine bundles based on lazy imports detected through <link rel="lazy-import" tags.