### PR TITLE
Fix issue importing bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Fixed a bug where bundling using generateShellMergeStrategy would result in
+  builds missing imports which should have been appended to shell.
+
 ## 2.0.0-pre.3 - 2017-01-31
 - Changed the way bundle documents are generated, so that bundles based on a
   source file retain their HTML structure instead of always being synthesized

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -67,17 +67,18 @@ export async function inlineHtmlImport(
     return;
   }
 
-  // If we've previously visited a url that is part of a bundle, it means we've
-  // handled that entire bundle, so we guard against inlining any other file
-  // from that bundle by checking the visited urls for the bundle url itself.
-  if (visitedUrls.has(importBundleUrl)) {
-    astUtils.removeElementAndNewline(htmlImport);
-    return;
-  }
-
   // If the html import refers to a file which is bundled and has a different
   // url, then lets just rewrite the href to point to the bundle url.
   if (importBundleUrl !== docBundle.url) {
+    // If we've previously visited a url that is part of another bundle, it
+    // means we've handled that entire bundle, so we guard against inlining any
+    // other file from that bundle by checking the visited urls for the bundle
+    // url itself.
+    if (visitedUrls.has(importBundleUrl)) {
+      astUtils.removeElementAndNewline(htmlImport);
+      return;
+    }
+
     const relative =
         urlUtils.relativeUrl(docUrl, importBundleUrl) || importBundleUrl;
     dom5.setAttribute(htmlImport, 'href', relative);

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -103,7 +103,7 @@ suite('Bundler', () => {
       const strategy = generateShellMergeStrategy(shell, 2);
       return bundleMultiple([shell, entrypoint1, entrypoint2], strategy)
           .then((docs) => {
-            //      assert.equal(docs.size, 3);
+            assert.equal(docs.size, 3);
             const shellDoc: parse5.ASTNode = docs.get(shell)!.ast;
             assert.isDefined(shellDoc);
             const entrypoint1Doc = docs.get(entrypoint1)!;

--- a/test/html/shards/shop_style_project/shell.html
+++ b/test/html/shards/shop_style_project/shell.html
@@ -1,0 +1,1 @@
+<div id="shell"></div>


### PR DESCRIPTION
An issue surfaced when trying to execute the shell merge strategy in polymer-build where some imports were not making it into the shell.  I scratched my head a lot and eventually followed the problem to a logic error that came in with mass refactor that had no scenario to cover it.

Anyways, I've added a regression test for the problem scenario (a file linking to the url of its own bundle stopping import of subsequent files) and a fix.