### PR TITLE
Even better strategy generators

### DIFF
--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -278,10 +278,12 @@ export function mergeMatchingBundles(
     bundles: Bundle[], predicate: (bundle: Bundle) => boolean): Bundle[] {
   const newBundles = Array.from(bundles);
   const bundlesToMerge = newBundles.filter(predicate);
-  for (const bundle of bundlesToMerge) {
-    newBundles.splice(newBundles.indexOf(bundle), 1);
+  if (bundlesToMerge.length > 1) {
+    for (const bundle of bundlesToMerge) {
+      newBundles.splice(newBundles.indexOf(bundle), 1);
+    }
+    newBundles.push(mergeBundles(bundlesToMerge));
   }
-  newBundles.push(mergeBundles(bundlesToMerge));
   return newBundles;
 }
 

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -172,18 +172,15 @@ export function generateEagerMergeStrategy(entrypoint: UrlString):
  * function and merges them into the bundle containing the target file.
  */
 export function generateMatchMergeStrategy(
-    target: UrlString,
-    predicate: (matchBundle: Bundle, targetBundle: Bundle) =>
-        boolean): BundleStrategy {
+    target: UrlString, predicate: (b: Bundle) => boolean): BundleStrategy {
   return (bundles: Bundle[]): Bundle[] => {
-    let targetBundle = bundles.find((bundle) => bundle.files.has(target));
+    let targetBundle = bundles.find((b) => b.files.has(target));
     if (!targetBundle) {
       throw new Error(`No bundle found containing file ${target}`);
     }
     const newBundles = Array.from(bundles);
-    const bundlesToMerge = newBundles.filter(
-        (matchBundle) => matchBundle === targetBundle ||
-            predicate(matchBundle, targetBundle!));
+    const bundlesToMerge =
+        newBundles.filter((b) => b === targetBundle || predicate(b));
     for (const bundle of bundlesToMerge) {
       newBundles.splice(newBundles.indexOf(bundle), 1);
     }

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -164,7 +164,7 @@ export function generateEagerMergeStrategy(entrypoint: UrlString):
     BundleStrategy {
   return generateMatchMergeStrategy(
       entrypoint,
-      b => b.entrypoints.has(entrypoint) && !getBundleEntrypoint(b));
+      (b) => b.entrypoints.has(entrypoint) && !getBundleEntrypoint(b));
 }
 
 /**
@@ -176,13 +176,13 @@ export function generateMatchMergeStrategy(
     predicate: (matchBundle: Bundle, targetBundle: Bundle) =>
         boolean): BundleStrategy {
   return (bundles: Bundle[]): Bundle[] => {
-    let targetBundle = bundles.find(bundle => bundle.files.has(target));
+    let targetBundle = bundles.find((bundle) => bundle.files.has(target));
     if (!targetBundle) {
       throw new Error(`No bundle found containing file ${target}`);
     }
     const newBundles = Array.from(bundles);
     const bundlesToMerge = newBundles.filter(
-        matchBundle => matchBundle === targetBundle ||
+        (matchBundle) => matchBundle === targetBundle ||
             predicate(matchBundle, targetBundle!));
     for (const bundle of bundlesToMerge) {
       newBundles.splice(newBundles.indexOf(bundle), 1);
@@ -211,8 +211,8 @@ export function generateSharedDepsMergeStrategy(minEntrypoints?: number):
   }
   return (bundles: Bundle[]): Bundle[] => mergeMatchingBundles(
              bundles,
-             bundle => bundle.entrypoints.size >= minEntrypoints &&
-                 !getBundleEntrypoint(bundle));
+             (b) => b.entrypoints.size >= minEntrypoints &&
+                 !getBundleEntrypoint(b));
 }
 
 /**
@@ -226,10 +226,9 @@ export function generateShellMergeStrategy(
   }
   return composeStrategies([
     generateEagerMergeStrategy(shell),
-    generateSharedDepsMergeStrategy(minEntrypoints),
     generateMatchMergeStrategy(
         shell,
-        b => b.entrypoints.size >= minEntrypoints && !getBundleEntrypoint(b))
+        (b) => b.entrypoints.size >= minEntrypoints && !getBundleEntrypoint(b))
   ]);
 }
 

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -193,10 +193,8 @@ export function generateSharedDepsMergeStrategy(minEntrypoints?: number):
   if (minEntrypoints === undefined) {
     minEntrypoints = 2;
   }
-  return (bundles: Bundle[]): Bundle[] => mergeMatchingBundles(
-             bundles,
-             (b) => b.entrypoints.size >= minEntrypoints &&
-                 !getBundleEntrypoint(b));
+  return generateMatchMergeStrategy(
+      (b) => b.entrypoints.size >= minEntrypoints && !getBundleEntrypoint(b));
 }
 
 /**

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -193,6 +193,9 @@ export function generateSharedDepsMergeStrategy(minEntrypoints?: number):
   if (minEntrypoints === undefined) {
     minEntrypoints = 2;
   }
+  if (minEntrypoints < 0) {
+    throw new Error(`Minimum entrypoints argument must be non-negative`);
+  }
   return generateMatchMergeStrategy(
       (b) => b.entrypoints.size >= minEntrypoints && !getBundleEntrypoint(b));
 }
@@ -205,6 +208,9 @@ export function generateShellMergeStrategy(
     shell: UrlString, minEntrypoints?: number): BundleStrategy {
   if (minEntrypoints === undefined) {
     minEntrypoints = 2;
+  }
+  if (minEntrypoints < 0) {
+    throw new Error(`Minimum entrypoints argument must be non-negative`);
   }
   return composeStrategies([
     generateEagerMergeStrategy(shell),

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -226,7 +226,7 @@ function _rewriteImportedElementAttrUrls(
  */
 function _rewriteImportedStyleTextUrls(
     importUrl: UrlString, mainDocUrl: UrlString, cssText: string): string {
-  return cssText.replace(constants.URL, match => {
+  return cssText.replace(constants.URL, (match) => {
     let path = match.replace(/["']/g, '').slice(4, -1);
     path = urlUtils.rewriteImportedRelPath(importUrl, mainDocUrl, path);
     return 'url("' + path + '")';

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -23,7 +23,7 @@ export interface Matcher { (node: parse5.ASTNode): boolean; }
 ;
 
 export const urlAttrMatchers: (Matcher)[] =
-    constants.URL_ATTR.map(attr => predicates.hasAttr(attr));
+    constants.URL_ATTR.map((attr) => predicates.hasAttr(attr));
 
 export const urlAttrs: Matcher = predicates.OR.apply(null, urlAttrMatchers);
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -134,16 +134,20 @@ suite('BundleManifest', () => {
       ].map(deserializeBundle);
 
       const strategyABCD = composeStrategies([
-        generateMatchMergeStrategy('B', (b) => b.entrypoints.has('A')),
-        generateMatchMergeStrategy('D', (b) => b.entrypoints.has('C'))
+        generateMatchMergeStrategy(
+            (b) => b.files.has('B') || b.entrypoints.has('A')),
+        generateMatchMergeStrategy(
+            (b) => b.files.has('D') || b.entrypoints.has('C'))
       ]);
 
       const composedABCD = strategyABCD(bundles).map(serializeBundle).sort();
       assert.deepEqual(composedABCD, ['[A,B,C,D]->[1,2,3,4,5,6,7,8,A,B,C,D]']);
 
       const strategyCDBD = composeStrategies([
-        generateMatchMergeStrategy('D', (b) => b.entrypoints.has('C')),
-        generateMatchMergeStrategy('D', (b) => b.entrypoints.has('B'))
+        generateMatchMergeStrategy(
+            (b) => b.files.has('D') || b.entrypoints.has('C')),
+        generateMatchMergeStrategy(
+            (b) => b.files.has('D') || b.entrypoints.has('B'))
       ]);
 
       const composedCDBD = strategyCDBD(bundles).map(serializeBundle).sort();
@@ -222,11 +226,6 @@ suite('BundleManifest', () => {
             '[D]->[8,D]',
             '[E]->[E]'
           ]);
-        });
-
-        test('throws an error if shell does not exist in any bundle', () => {
-          const eagerStrategy = generateEagerMergeStrategy('X');
-          assert.throws(() => eagerStrategy(bundles));
         });
       });
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -134,16 +134,16 @@ suite('BundleManifest', () => {
       ].map(deserializeBundle);
 
       const strategyABCD = composeStrategies([
-        generateMatchMergeStrategy('B', b => b.entrypoints.has('A')),
-        generateMatchMergeStrategy('D', b => b.entrypoints.has('C'))
+        generateMatchMergeStrategy('B', (b) => b.entrypoints.has('A')),
+        generateMatchMergeStrategy('D', (b) => b.entrypoints.has('C'))
       ]);
 
       const composedABCD = strategyABCD(bundles).map(serializeBundle).sort();
       assert.deepEqual(composedABCD, ['[A,B,C,D]->[1,2,3,4,5,6,7,8,A,B,C,D]']);
 
       const strategyCDBD = composeStrategies([
-        generateMatchMergeStrategy('D', b => b.entrypoints.has('C')),
-        generateMatchMergeStrategy('D', b => b.entrypoints.has('B'))
+        generateMatchMergeStrategy('D', (b) => b.entrypoints.has('C')),
+        generateMatchMergeStrategy('D', (b) => b.entrypoints.has('B'))
       ]);
 
       const composedCDBD = strategyCDBD(bundles).map(serializeBundle).sort();

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -16,7 +16,7 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 import * as chai from 'chai';
 
-import {Bundle, BundleManifest, generateBundles, generateSharedDepsMergeStrategy, generateShellMergeStrategy, invertMultimap, TransitiveDependenciesMap} from '../bundle-manifest';
+import {Bundle, BundleManifest, composeStrategies, generateBundles, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedDepsMergeStrategy, generateShellMergeStrategy, invertMultimap, TransitiveDependenciesMap} from '../bundle-manifest';
 
 chai.config.showDiff = true;
 
@@ -120,6 +120,135 @@ suite('BundleManifest', () => {
 
   suite('BundleStrategy', () => {
 
+    test('composeStrategies', () => {
+
+      const bundles: Bundle[] = [
+        '[A]->[1,A]',
+        '[B]->[2,B]',
+        '[C]->[3,C]',
+        '[A,B]->[4]',
+        '[A,C]->[5]',
+        '[B,C]->[6]',
+        '[A,B,C]->[7]',
+        '[D]->[8,D]'
+      ].map(deserializeBundle);
+
+      const strategyABCD = composeStrategies([
+        generateMatchMergeStrategy('B', b => b.entrypoints.has('A')),
+        generateMatchMergeStrategy('D', b => b.entrypoints.has('C'))
+      ]);
+
+      const composedABCD = strategyABCD(bundles).map(serializeBundle).sort();
+      assert.deepEqual(composedABCD, ['[A,B,C,D]->[1,2,3,4,5,6,7,8,A,B,C,D]']);
+
+      const strategyCDBD = composeStrategies([
+        generateMatchMergeStrategy('D', b => b.entrypoints.has('C')),
+        generateMatchMergeStrategy('D', b => b.entrypoints.has('B'))
+      ]);
+
+      const composedCDBD = strategyCDBD(bundles).map(serializeBundle).sort();
+      assert.deepEqual(
+          composedCDBD, ['[A,B,C,D]->[2,3,4,5,6,7,8,B,C,D]', '[A]->[1,A]']);
+    });
+
+    suite('generateEagerMergeStrategy', () => {
+
+      suite('simple dependency graph', () => {
+        const bundles: Bundle[] = [
+          '[A]->[1,A]',
+          '[A,B]->[2]',
+          '[A,B,C]->[3]',
+          '[B]->[4,B]',
+          '[B,C]->[5]',
+          '[B,C,D]->[6]',
+          '[C]->[7,C]',
+          '[D]->[8,D]',
+          '[E]->[E]',
+        ].map(deserializeBundle);
+
+        const eagerStrategyA = generateEagerMergeStrategy('A');
+        const eagerA = eagerStrategyA(bundles).map(serializeBundle).sort();
+        const eagerStrategyB = generateEagerMergeStrategy('B');
+        const eagerB = eagerStrategyB(bundles).map(serializeBundle).sort();
+        const eagerStrategyD = generateEagerMergeStrategy('D');
+        const eagerD = eagerStrategyD(bundles).map(serializeBundle).sort();
+        const eagerStrategyE = generateEagerMergeStrategy('E');
+        const eagerE = eagerStrategyE(bundles).map(serializeBundle).sort();
+
+        test('merges 2 bundles into eager A', () => {
+          assert.deepEqual(eagerA, [
+            '[A,B,C]->[1,2,3,A]',
+            '[B,C,D]->[6]',
+            '[B,C]->[5]',
+            '[B]->[4,B]',
+            '[C]->[7,C]',
+            '[D]->[8,D]',
+            '[E]->[E]'
+          ]);
+        });
+
+        test('merges 4 bundles into eager B', () => {
+          assert.deepEqual(eagerB, [
+            '[A,B,C,D]->[2,3,4,5,6,B]',
+            '[A]->[1,A]',
+            '[C]->[7,C]',
+            '[D]->[8,D]',
+            '[E]->[E]'
+          ]);
+        });
+
+        test('merges 1 bundle into shell D', () => {
+          assert.deepEqual(eagerD, [
+            '[A,B,C]->[3]',
+            '[A,B]->[2]',
+            '[A]->[1,A]',
+            '[B,C,D]->[6,8,D]',
+            '[B,C]->[5]',
+            '[B]->[4,B]',
+            '[C]->[7,C]',
+            '[E]->[E]'
+          ]);
+        });
+
+        test('merges no bundles into shell E', () => {
+          assert.deepEqual(eagerE, [
+            '[A,B,C]->[3]',
+            '[A,B]->[2]',
+            '[A]->[1,A]',
+            '[B,C,D]->[6]',
+            '[B,C]->[5]',
+            '[B]->[4,B]',
+            '[C]->[7,C]',
+            '[D]->[8,D]',
+            '[E]->[E]'
+          ]);
+        });
+
+        test('throws an error if shell does not exist in any bundle', () => {
+          const eagerStrategy = generateEagerMergeStrategy('X');
+          assert.throws(() => eagerStrategy(bundles));
+        });
+      });
+
+      test('will not merge entrypoint bundles', () => {
+        const bundles = [
+          '[A]->[1,A]',  //
+          '[A,B]->[2,B]',
+          '[A,C]->[3]',
+          '[A,D]->[5,D]'
+        ].map(deserializeBundle);
+        const eagerStrategy = generateEagerMergeStrategy('A');
+        const eager = eagerStrategy(bundles).map(serializeBundle).sort();
+        assert.deepEqual(
+            eager,
+            [
+              '[A,B]->[2,B]',  //
+              '[A,C]->[1,3,A]',
+              '[A,D]->[5,D]'
+            ]);
+      });
+    });
+
     suite('generateSharedDepsMergeStrategy', () => {
 
       const bundles: Bundle[] = [
@@ -183,7 +312,7 @@ suite('BundleManifest', () => {
       // TODO(usergenic): It feels like the generateSharedDepsMergeStrategy
       // could do something smarter for the case where groups of deps are
       // exclusive.  Leaving this test here as a future behavior to consider.
-      test.skip('produces a function which generates 2 shared bundles', () => {
+      test.skip('generates distinct bundles for exclusive graphs', () => {
 
         const bundlesSplit: Bundle[] = [
           // group [A,B,C]
@@ -206,12 +335,12 @@ suite('BundleManifest', () => {
 
         assert.deepEqual(bundles2, [
           '[A,B,C]->[2,4]',
-          '[A]->[A,1]',
-          '[B]->[B,3]',
-          '[C]->[C,5]',
+          '[A]->[1,A]',
+          '[B]->[3,B]',
+          '[C]->[5,C]',
           '[D,E,F]->[7,9]',
-          '[D]->[D,6]',
-          '[E]->[E,8]',
+          '[D]->[6,D]',
+          '[E]->[8,E]',
           '[F]->[F]'
         ]);
       });
@@ -219,75 +348,49 @@ suite('BundleManifest', () => {
 
     suite('generateShellMergeStrategy', () => {
 
-      suite('simple dependency graph', () => {
-        const bundles: Bundle[] = [
-          '[A]->[A,1]',
-          '[A,B]->[2]',
-          '[A,B,C]->[3]',
-          '[B]->[B,4]',
-          '[B,C]->[5]',
-          '[B,C,D]->[6]',
-          '[C]->[C,7]',
-          '[D]->[D,8]'
+      test('will merge shop-style shell app dependencies into shell', () => {
+        const bundles = [
+          '[CART]->[1,CART]',
+          '[CART,CHECKOUT]->[2]',
+          '[CART,LIST]->[3]',
+          '[CHECKOUT]->[4,CHECKOUT]',
+          '[DETAIL]->[5,DETAIL]',
+          '[DETAIL,LIST]->[6]',
+          '[LIST]->[7,LIST]',
+          '[SHELL]->[8,SHELL]'
         ].map(deserializeBundle);
 
-        const shellStrategy3 = generateShellMergeStrategy('D', 3);
-        const shelled3 = shellStrategy3(bundles).map(serializeBundle).sort();
-        const shellStrategy2 = generateShellMergeStrategy('D', 2);
-        const shelled2 = shellStrategy2(bundles).map(serializeBundle).sort();
-        const shellStrategyDefault = generateShellMergeStrategy('D');
-        const shelledDefault =
-            shellStrategyDefault(bundles).map(serializeBundle).sort();
+        const shellStrategy2 = generateShellMergeStrategy('SHELL', 2);
+        const shelled = shellStrategy2(bundles).map(serializeBundle).sort();
 
-        test('merge shared deps with min 3 entrypoints in shell', () => {
-          assert.deepEqual(shelled3, [
-            '[A,B,C,D]->[3,6,8,D]',
-            '[A,B]->[2]',
-            '[A]->[1,A]',
-            '[B,C]->[5]',
-            '[B]->[4,B]',
-            '[C]->[7,C]'
-          ]);
-        });
-
-        test('merges shared deps with min 2 entrypoints in shell', () => {
-          assert.deepEqual(shelled2, [
-            '[A,B,C,D]->[2,3,5,6,8,D]',
-            '[A]->[1,A]',
-            '[B]->[4,B]',
-            '[C]->[7,C]'
-          ]);
-        });
-
-        test('default min entrypoints is 2', () => {
-          assert.deepEqual(shelledDefault, shelled2);
-        });
-
-        test('throws an error if shell does not exist in any bundle', () => {
-          const shellStrategy = generateShellMergeStrategy('X');
-          assert.throws(() => shellStrategy(bundles));
-        });
+        assert.deepEqual(shelled, [
+          '[CART,CHECKOUT,DETAIL,LIST,SHELL]->[2,3,6,8,SHELL]',
+          '[CART]->[1,CART]',
+          '[CHECKOUT]->[4,CHECKOUT]',
+          '[DETAIL]->[5,DETAIL]',
+          '[LIST]->[7,LIST]'
+        ]);
       });
 
-      test('shell merge strategy will not merge entrypoints into shell', () => {
+      test('will not merge entrypoint bundles into the shell', () => {
         const bundles = [
           '[A]->[1,A]',  //
           '[A,B]->[2,B]',
           '[A,C]->[3]',
-          '[SHELL]->[5,SHELL]'
+          '[A,C,D]->[5]',
+          '[B,D]->[6,D]'
         ].map(deserializeBundle);
-        const shellStrategy = generateShellMergeStrategy('SHELL');
+        const shellStrategy = generateShellMergeStrategy('B', 2);
         const shelled = shellStrategy(bundles).map(serializeBundle).sort();
         assert.deepEqual(
             shelled,
             [
-              '[A,B]->[2,B]',  //
-              '[A,C,SHELL]->[3,5,SHELL]',
-              '[A]->[1,A]'
+              '[A,B,C,D]->[2,3,5,B]',  //
+              '[A]->[1,A]',
+              '[B,D]->[6,D]'
             ]);
       });
     });
-
   });
 
   suite('Shop example', () => {

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -262,6 +262,8 @@ suite('BundleManifest', () => {
         '[D]->[8,D]'
       ].map(deserializeBundle);
 
+      const strategy9 = generateSharedDepsMergeStrategy(9);
+      const bundles9 = strategy9(bundles).map(serializeBundle).sort();
       const strategy3 = generateSharedDepsMergeStrategy(3);
       const bundles3 = strategy3(bundles).map(serializeBundle).sort();
       const strategy2 = generateSharedDepsMergeStrategy(2);
@@ -307,6 +309,11 @@ suite('BundleManifest', () => {
           '[C]->[7,C]',
           '[D]->[8,D]'
         ]);
+      });
+
+      test('does not change bundles if threshold is not met', () => {
+        const originalBundles = bundles.map(serializeBundle).sort();
+        assert.deepEqual(bundles9, originalBundles);
       });
 
       // TODO(usergenic): It feels like the generateSharedDepsMergeStrategy

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -72,13 +72,15 @@ suite('Bundler', () => {
       const strategy = generateSharedDepsMergeStrategy(2);
       return bundleMultiple([common, entrypoint1, entrypoint2], strategy)
           .then((docs) => {
-            assert.equal(docs.size, 3);
+            assert.equal(docs.size, 4);
             const commonDoc: parse5.ASTNode = docs.get(common)!.ast;
             assert.isDefined(commonDoc);
-            const entrypoint1Doc = docs.get(entrypoint1)!;
+            const entrypoint1Doc = docs.get(entrypoint1)!.ast;
             assert.isDefined(entrypoint1Doc);
-            const entrypoint2Doc = docs.get(entrypoint2)!;
+            const entrypoint2Doc = docs.get(entrypoint2)!.ast;
             assert.isDefined(entrypoint2Doc);
+            const sharedDoc = docs.get('shared_bundle_1.html')!.ast;
+            assert.isDefined(sharedDoc);
             const commonModule = domModulePredicate('common-module');
             const elOne = domModulePredicate('el-one');
             const elTwo = domModulePredicate('el-two');
@@ -87,15 +89,13 @@ suite('Bundler', () => {
 
             // Check that all the dom modules are in their expected shards
             assertContainsAndExcludes(
-                commonDoc, [commonModule, depOne], [elOne, elTwo, depTwo]);
+                commonDoc, [commonModule], [elOne, elTwo, depOne, depTwo]);
             assertContainsAndExcludes(
-                entrypoint1Doc.ast,
-                [elOne],
-                [commonModule, elTwo, depOne, depTwo]);
+                sharedDoc, [depOne], [elOne, elTwo, depTwo]);
             assertContainsAndExcludes(
-                entrypoint2Doc.ast,
-                [elTwo, depTwo],
-                [commonModule, elOne, depOne]);
+                entrypoint1Doc, [elOne], [commonModule, elTwo, depOne, depTwo]);
+            assertContainsAndExcludes(
+                entrypoint2Doc, [elTwo, depTwo], [commonModule, elOne, depOne]);
           });
     });
 
@@ -106,9 +106,9 @@ suite('Bundler', () => {
             assert.equal(docs.size, 3);
             const shellDoc: parse5.ASTNode = docs.get(shell)!.ast;
             assert.isDefined(shellDoc);
-            const entrypoint1Doc = docs.get(entrypoint1)!;
+            const entrypoint1Doc = docs.get(entrypoint1)!.ast;
             assert.isDefined(entrypoint1Doc);
-            const entrypoint2Doc = docs.get(entrypoint2)!;
+            const entrypoint2Doc = docs.get(entrypoint2)!.ast;
             assert.isDefined(entrypoint2Doc);
             const shellDiv = dom5.predicates.hasAttrValue('id', 'shell');
             const commonModule = domModulePredicate('common-module');
@@ -123,13 +123,9 @@ suite('Bundler', () => {
                 [shellDiv, commonModule, depOne],
                 [elOne, elTwo, depTwo]);
             assertContainsAndExcludes(
-                entrypoint1Doc.ast,
-                [elOne],
-                [commonModule, elTwo, depOne, depTwo]);
+                entrypoint1Doc, [elOne], [commonModule, elTwo, depOne, depTwo]);
             assertContainsAndExcludes(
-                entrypoint2Doc.ast,
-                [elTwo, depTwo],
-                [commonModule, elOne, depOne]);
+                entrypoint2Doc, [elTwo, depTwo], [commonModule, elOne, depOne]);
           });
     });
   });

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -54,7 +54,7 @@ export function relativeUrl(fromUri: UrlString, toUri: UrlString): UrlString {
   // Return the toUri as-is if there are conflicting components which
   // prohibit calculating a relative form.
   if (sharedRelativeUrlProperties.some(
-          p => toUrl[p] !== null && fromUrl[p] !== toUrl[p])) {
+          (p) => toUrl[p] !== null && fromUrl[p] !== toUrl[p])) {
     return toUri;
   }
   const fromDir = fromUrl.pathname !== undefined ?
@@ -64,7 +64,7 @@ export function relativeUrl(fromUri: UrlString, toUri: UrlString): UrlString {
   // Note, below, the _ character is appended so that paths with trailing
   // slash retain the trailing slash in the path.relative result.
   const relPath = path.relative(fromDir, toDir + '_').replace(/_$/, '');
-  sharedRelativeUrlProperties.forEach(p => toUrl[p] = null);
+  sharedRelativeUrlProperties.forEach((p) => toUrl[p] = null);
   toUrl.path = undefined;
   toUrl.pathname = relPath;
   return url.format(toUrl);


### PR DESCRIPTION
@justinfagnani @garlicnation PTAL.  Here is a cleaned up set of bundle strategy generators which are composed in a (hopefully) clearer and more intention-revealing way.  I'm making this a new pull request in case for some reason we want to go with the other one instead after you look at this.

In particular, Justin and I talked this morning about how a shell strategy might just care about its own dependencies-- that turns out to be false for the shell case, because the shell test cases show an essentially empty shell (i.e. it has no transitive dependencies of its own).  However, we did talk about how a shell should eagerly include all of its own transitive dependencies directly since it will need them and it is loaded with everything else, so now the shell reliably gobbles up all of its own transitive dependencies now, because its composition includes the new `generateEagerMergeStrategy`.

I should point out that by revisiting the way these strategy generators were built, it actually revealed a previously undiscovered _error_ in the `generateSharedDepsMergeStrategy`, which you can see in the fix to the `shards_test.ts` around line 75 in the test called 'with 3 entrypoints, all deps are in their places'.

The previous strategy was incorrectly bundling `dep1` into the common bundle.  Common, being an entrypoint, should not have been pulled into a bundle which did not represent its own transitive dependencies, but that's what was happening.  Fixing the strategies required updating that test to demonstrate how `shared_bundle_1.html` is created as a result.  The remainder of changes to that `shards_test.ts` file are cosmetic.

There are a lot of new tests in the `bundle-manifest_test.ts` doc but I also simplified the tests stylistically so the existing tests there don't prove anything new, they just are easier to read (i think).

(Note I included some `//` comments with no text afterwards in a couple of lines just to force the formatter to splay the array contents across multiple lines.)