### PR TITLE
Updated changelog for 2.0.0-pre4 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0-pre.4 - 2017-02-03
+## 2.0.0-pre.4 - 2017-02-06
 - Fixed a bug where bundling using generateShellMergeStrategy would result in
   builds missing imports which should have been appended to shell.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-
+## 2.0.0-pre.4 - 2017-02-03
 - Fixed a bug where bundling using generateShellMergeStrategy would result in
   builds missing imports which should have been appended to shell.
 


### PR DESCRIPTION
Cutting polymer-bundler 2.0.0-pre4 release, so updating changelog.

 - [x] CHANGELOG.md has been updated
