### PR TITLE
When bundling documents which use the `<base>` tag, emulate it and remove it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0-pre.5 - 2017-02-14
-- Handle base tags when resolving imports.
+## 2.0.0-pre.5 - 2017-02-15
+- Handle `<base href="...">` values correctly when resolving imports.
+- Apply `<base target="...">` to links and forms in the same document as
+  appropriate.
 
 ## 2.0.0-pre.4 - 2017-02-06
 - Fixed a bug where bundling using generateShellMergeStrategy would result in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.0.0-pre.5 - 2017-02-15
-- Handle `<base href="...">` values correctly when resolving imports.
+## Unreleased
+- Handle `<base href="...">` values correctly when inlining imports.
 - Apply `<base target="...">` to links and forms in the same document as
   appropriate.
+
+## 2.0.0-pre.5 - 2017-02-14
+- Handle base tags when resolving the dependency graph of imports.
 
 ## 2.0.0-pre.4 - 2017-02-06
 - Fixed a bug where bundling using generateShellMergeStrategy would result in

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -191,7 +191,6 @@ export class Bundler {
 
     this._appendHtmlImportsForBundle(document, docBundle);
     importUtils.rebaseDocument(docUrl, document);
-    importUtils.rewriteImportedUrls(document, docUrl, docUrl);
 
     await this._inlineHtmlImports(docUrl, document, docBundle, bundleManifest);
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -188,7 +188,9 @@ export class Bundler {
       bundleImports?: Set<string>): Promise<ASTNode> {
     const docUrl = docBundle.url;
     const document = await this._prepareBundleDocument(docBundle);
+
     this._appendHtmlImportsForBundle(document, docBundle);
+    importUtils.rebaseDocument(docUrl, document);
     importUtils.rewriteImportedUrls(document, docUrl, docUrl);
 
     await this._inlineHtmlImports(docUrl, document, docBundle, bundleManifest);

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -190,7 +190,7 @@ export class Bundler {
     const document = await this._prepareBundleDocument(docBundle);
 
     this._appendHtmlImportsForBundle(document, docBundle);
-    importUtils.rebaseDocument(docUrl, document);
+    importUtils.debaseDocument(docUrl, document);
 
     await this._inlineHtmlImports(docUrl, document, docBundle, bundleManifest);
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -190,7 +190,7 @@ export class Bundler {
     const document = await this._prepareBundleDocument(docBundle);
 
     this._appendHtmlImportsForBundle(document, docBundle);
-    importUtils.debaseDocument(docUrl, document);
+    importUtils.rewriteDocumentToEmulateBaseTag(docUrl, document);
 
     await this._inlineHtmlImports(docUrl, document, docBundle, bundleManifest);
 

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -35,7 +35,7 @@ async function _getTransitiveDependencies(
     url: UrlString, entrypoints: UrlString[], analyzer: Analyzer):
     Promise<DependencyMapEntry> {
       const document = await analyzer.analyze(url);
-      const documentBase = document.parsedDocument.baseUrl;
+      const baseUrl = document.parsedDocument.baseUrl;
       const imports = document.getByKind(
           'import', {externalPackages: true, imported: true});
       const eagerImports = new Set<UrlString>();
@@ -51,7 +51,7 @@ async function _getTransitiveDependencies(
           throw err;
         }
         const resolvedHtmlImportUrl = urlLib.resolve(
-            documentBase, urlUtils.relativeUrl(documentBase, htmlImport.url));
+            baseUrl, urlUtils.relativeUrl(baseUrl, htmlImport.url));
         switch (htmlImport.type) {
           case 'html-import':
             eagerImports.add(resolvedHtmlImportUrl);

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -13,9 +13,6 @@
  */
 import {AssertionError} from 'assert';
 import {Analyzer} from 'polymer-analyzer';
-import * as urlLib from 'url';
-
-import * as urlUtils from './url-utils';
 import {UrlString} from './url-utils';
 
 export interface DepsIndex {
@@ -35,7 +32,6 @@ async function _getTransitiveDependencies(
     url: UrlString, entrypoints: UrlString[], analyzer: Analyzer):
     Promise<DependencyMapEntry> {
       const document = await analyzer.analyze(url);
-      const baseUrl = document.parsedDocument.baseUrl;
       const imports = document.getByKind(
           'import', {externalPackages: true, imported: true});
       const eagerImports = new Set<UrlString>();
@@ -50,14 +46,13 @@ async function _getTransitiveDependencies(
           }
           throw err;
         }
-        const resolvedHtmlImportUrl = urlLib.resolve(
-            baseUrl, urlUtils.relativeUrl(baseUrl, htmlImport.url));
+
         switch (htmlImport.type) {
           case 'html-import':
-            eagerImports.add(resolvedHtmlImportUrl);
+            eagerImports.add(htmlImport.url);
             break;
           case 'lazy-html-import':
-            lazyImports.add(resolvedHtmlImportUrl);
+            lazyImports.add(htmlImport.url);
             break;
         }
       }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -28,38 +28,6 @@ import {UrlString} from './url-utils';
 // building a class to encapsulate the common document details like docUrl and
 // docBundle and global notions like manifest etc.
 
-/*
- * Given an import document with a base tag, transform all of its URLs and set
- * link and form target attributes and remove the base tag.
- */
-export function rewriteDocumentToEmulateBaseTag(
-    docUrl: UrlString, importDoc: ASTNode) {
-  const baseTag = dom5.query(importDoc, matchers.base);
-  const p = dom5.predicates;
-  // If there's no base tag, there's nothing to do.
-  if (!baseTag) {
-    return;
-  }
-  for (const baseTag of dom5.queryAll(importDoc, matchers.base)) {
-    astUtils.removeElementAndNewline(baseTag);
-  }
-  if (dom5.predicates.hasAttr('href')(baseTag)) {
-    const baseUrl = urlLib.resolve(docUrl, dom5.getAttribute(baseTag, 'href')!);
-    rewriteImportedUrls(importDoc, baseUrl, docUrl);
-  }
-  if (p.hasAttr('target')(baseTag)) {
-    const baseTarget = dom5.getAttribute(baseTag, 'target')!;
-    const tagsToTarget = dom5.queryAll(
-        importDoc,
-        p.AND(
-            p.OR(p.hasTagName('a'), p.hasTagName('form')),
-            p.NOT(p.hasAttr('target'))));
-    for (const tag of tagsToTarget) {
-      dom5.setAttribute(tag, 'target', baseTarget);
-    }
-  }
-}
-
 /**
  * Inline the contents of the html document returned by the link tag's href
  * at the location of the link tag and then remove the link tag.
@@ -125,7 +93,7 @@ export async function inlineHtmlImport(
 
   const importDoc = parse5.parseFragment(importSource);
   rewriteDocumentToEmulateBaseTag(resolvedImportUrl, importDoc);
-  rewriteImportedUrls(importDoc, resolvedImportUrl, docUrl);
+  rewriteDocumentBaseUrl(importDoc, resolvedImportUrl, docUrl);
   const nestedImports = dom5.queryAll(importDoc, matchers.htmlImport);
 
   // Move all of the import doc content after the html import.
@@ -195,7 +163,7 @@ export async function inlineStylesheet(
 
   const media = dom5.getAttribute(cssLink, 'media');
   const resolvedStylesheetContent =
-      _rewriteImportedStyleTextUrls(resolvedUrl, docUrl, stylesheetContent);
+      _rewriteCssTextBaseUrl(stylesheetContent, resolvedUrl, docUrl);
   const styleNode = dom5.constructors.element('style');
 
   if (media) {
@@ -207,40 +175,81 @@ export async function inlineStylesheet(
   return styleNode;
 }
 
+/*
+ * Given an import document with a base tag, transform all of its URLs and set
+ * link and form target attributes and remove the base tag.
+ */
+export function rewriteDocumentToEmulateBaseTag(
+    docUrl: UrlString, ast: ASTNode) {
+  const baseTag = dom5.query(ast, matchers.base);
+  const p = dom5.predicates;
+  // If there's no base tag, there's nothing to do.
+  if (!baseTag) {
+    return;
+  }
+  for (const baseTag of dom5.queryAll(ast, matchers.base)) {
+    astUtils.removeElementAndNewline(baseTag);
+  }
+  if (dom5.predicates.hasAttr('href')(baseTag)) {
+    const baseUrl = urlLib.resolve(docUrl, dom5.getAttribute(baseTag, 'href')!);
+    rewriteDocumentBaseUrl(ast, baseUrl, docUrl);
+  }
+  if (p.hasAttr('target')(baseTag)) {
+    const baseTarget = dom5.getAttribute(baseTag, 'target')!;
+    const tagsToTarget = dom5.queryAll(
+        ast,
+        p.AND(
+            p.OR(p.hasTagName('a'), p.hasTagName('form')),
+            p.NOT(p.hasAttr('target'))));
+    for (const tag of tagsToTarget) {
+      dom5.setAttribute(tag, 'target', baseTarget);
+    }
+  }
+}
+
 /**
  * Walk through an import document, and rewrite all urls so they are
  * correctly relative to the main document url as they've been
  * imported from the import url.
  */
-export function rewriteImportedUrls(
-    importDoc: ASTNode, importUrl: UrlString, mainDocUrl: UrlString) {
-  _rewriteImportedElementAttrUrls(importDoc, importUrl, mainDocUrl);
-  _rewriteImportedStyleUrls(importDoc, importUrl, mainDocUrl);
-  _setImportedDomModuleAssetpaths(importDoc, importUrl, mainDocUrl);
+export function rewriteDocumentBaseUrl(
+    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
+  _rewriteElementAttrsBaseUrl(ast, oldBaseUrl, newBaseUrl);
+  _rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl);
+  _setDomModuleAssetpaths(ast, oldBaseUrl, newBaseUrl);
+}
+
+/**
+ * Given a string of CSS, return a version where all occurrences of urls,
+ * have been rewritten based on the relationship of the old base url to the
+ * new base url.
+ */
+function _rewriteCssTextBaseUrl(
+    cssText: string, oldBaseUrl: UrlString, newBaseUrl: UrlString): string {
+  return cssText.replace(constants.URL, (match) => {
+    let path = match.replace(/["']/g, '').slice(4, -1);
+    path = urlUtils.rewriteHrefBaseUrl(path, oldBaseUrl, newBaseUrl);
+    return 'url("' + path + '")';
+  });
 }
 
 /**
  * Find all element attributes which express urls and rewrite them so they
- * are correctly relative to the main document url as they've been
- * imported from the import url.
+ * are based on the relationship of the old base url to the new base url.
  */
-function _rewriteImportedElementAttrUrls(
-    importDoc: ASTNode, importUrl: UrlString, mainDocUrl: UrlString) {
-  const nodes = dom5.queryAll(importDoc, matchers.urlAttrs);
+function _rewriteElementAttrsBaseUrl(
+    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
+  const nodes = dom5.queryAll(ast, matchers.urlAttrs);
   for (const node of nodes) {
     for (const attr of constants.URL_ATTR) {
       const attrValue = dom5.getAttribute(node, attr);
       if (attrValue && !urlUtils.isTemplatedUrl(attrValue)) {
         let relUrl: UrlString;
         if (attr === 'style') {
-          relUrl =
-              _rewriteImportedStyleTextUrls(importUrl, mainDocUrl, attrValue);
+          relUrl = _rewriteCssTextBaseUrl(attrValue, oldBaseUrl, newBaseUrl);
         } else {
           relUrl =
-              urlUtils.rewriteImportedRelPath(importUrl, mainDocUrl, attrValue);
-          if (attr === 'assetpath' && relUrl.slice(-1) !== '/') {
-            relUrl += '/';
-          }
+              urlUtils.rewriteHrefBaseUrl(attrValue, oldBaseUrl, newBaseUrl);
         }
         dom5.setAttribute(node, attr, relUrl);
       }
@@ -249,54 +258,36 @@ function _rewriteImportedElementAttrUrls(
 }
 
 /**
- * Given a string of CSS, return a version where all occurrences of urls,
- * have been rewritten based on the relationship of the import url to the
- * main doc url.
- * TODO(usergenic): This is a static method that should probably be moved to
- * urlUtils or similar.
+ * Find all urls in imported style nodes and rewrite them so they are based
+ * on the relationship of the old base url to the new base url.
  */
-function _rewriteImportedStyleTextUrls(
-    importUrl: UrlString, mainDocUrl: UrlString, cssText: string): string {
-  return cssText.replace(constants.URL, (match) => {
-    let path = match.replace(/["']/g, '').slice(4, -1);
-    path = urlUtils.rewriteImportedRelPath(importUrl, mainDocUrl, path);
-    return 'url("' + path + '")';
-  });
-}
-
-/**
- * Find all urls in imported style nodes and rewrite them so they are now
- * correctly relative to the main document url as they've been imported from
- * the import url.
- */
-function _rewriteImportedStyleUrls(
-    importDoc: ASTNode, importUrl: UrlString, mainDocUrl: UrlString) {
+function _rewriteStyleTagsBaseUrl(
+    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
   const styleNodes = dom5.queryAll(
-      importDoc,
-      matchers.styleMatcher,
-      undefined,
-      dom5.childNodesIncludeTemplate);
+      ast, matchers.styleMatcher, undefined, dom5.childNodesIncludeTemplate);
   for (const node of styleNodes) {
     let styleText = dom5.getTextContent(node);
-    styleText = _rewriteImportedStyleTextUrls(importUrl, mainDocUrl, styleText);
+    styleText = _rewriteCssTextBaseUrl(styleText, oldBaseUrl, newBaseUrl);
     dom5.setTextContent(node, styleText);
   }
 }
 
 /**
  * Set the assetpath attribute of all imported dom-modules which don't yet
- * have them.
+ * have them if the base urls are different.
  */
-function _setImportedDomModuleAssetpaths(
-    importDoc: ASTNode, importUrl: UrlString, mainDocUrl: UrlString) {
-  const domModules =
-      dom5.queryAll(importDoc, matchers.domModuleWithoutAssetpath);
+function _setDomModuleAssetpaths(
+    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
+  const domModules = dom5.queryAll(ast, matchers.domModuleWithoutAssetpath);
   for (let i = 0, node: ASTNode; i < domModules.length; i++) {
     node = domModules[i];
-    const assetPathUrl =
-        urlUtils.relativeUrl(
-            mainDocUrl, urlUtils.stripUrlFileSearchAndHash(importUrl)) ||
-        './';
-    dom5.setAttribute(node, 'assetpath', assetPathUrl);
+    const assetPathUrl = urlUtils.relativeUrl(
+        newBaseUrl, urlUtils.stripUrlFileSearchAndHash(oldBaseUrl));
+
+    // There's no reason to set an assetpath on a dom-module if its different
+    // from the document's base.
+    if (assetPathUrl !== '') {
+      dom5.setAttribute(node, 'assetpath', assetPathUrl);
+    }
   }
 }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -32,7 +32,8 @@ import {UrlString} from './url-utils';
  * Given an import document with a base tag, transform all of its URLs and set
  * link and form target attributes and remove the base tag.
  */
-export function debaseDocument(docUrl: UrlString, importDoc: ASTNode) {
+export function rewriteDocumentToEmulateBaseTag(
+    docUrl: UrlString, importDoc: ASTNode) {
   const baseTag = dom5.query(importDoc, matchers.base);
   const p = dom5.predicates;
   // If there's no base tag, there's nothing to do.
@@ -123,7 +124,7 @@ export async function inlineHtmlImport(
   }
 
   const importDoc = parse5.parseFragment(importSource);
-  debaseDocument(resolvedImportUrl, importDoc);
+  rewriteDocumentToEmulateBaseTag(resolvedImportUrl, importDoc);
   rewriteImportedUrls(importDoc, resolvedImportUrl, docUrl);
   const nestedImports = dom5.queryAll(importDoc, matchers.htmlImport);
 

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -293,7 +293,9 @@ function _setImportedDomModuleAssetpaths(
   for (let i = 0, node: ASTNode; i < domModules.length; i++) {
     node = domModules[i];
     const assetPathUrl =
-        urlUtils.relativeUrl(mainDocUrl, urlUtils.debaseUrl(importUrl)) || './';
+        urlUtils.relativeUrl(
+            mainDocUrl, urlUtils.stripUrlFileSearchAndHash(importUrl)) ||
+        './';
     dom5.setAttribute(node, 'assetpath', assetPathUrl);
   }
 }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -92,7 +92,7 @@ export async function inlineHtmlImport(
   }
 
   const importDoc = parse5.parseFragment(importSource);
-  rebaseDocument(resolvedImportUrl, importDoc);
+  debaseDocument(resolvedImportUrl, importDoc);
   rewriteImportedUrls(importDoc, resolvedImportUrl, docUrl);
   const nestedImports = dom5.queryAll(importDoc, matchers.htmlImport);
 
@@ -179,7 +179,7 @@ export async function inlineStylesheet(
  * Given an import document, transform all of its URLs based on the document
  * base.
  */
-export async function rebaseDocument(docUrl: UrlString, importDoc: ASTNode) {
+export async function debaseDocument(docUrl: UrlString, importDoc: ASTNode) {
   const baseTag = dom5.query(importDoc, matchers.base);
   // If there's no base tag, there's nothing to do.
   if (!baseTag) {

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -34,6 +34,7 @@ import {UrlString} from './url-utils';
  */
 export async function debaseDocument(docUrl: UrlString, importDoc: ASTNode) {
   const baseTag = dom5.query(importDoc, matchers.base);
+  const p = dom5.predicates;
   // If there's no base tag, there's nothing to do.
   if (!baseTag) {
     return;
@@ -45,9 +46,14 @@ export async function debaseDocument(docUrl: UrlString, importDoc: ASTNode) {
     const baseUrl = urlLib.resolve(docUrl, dom5.getAttribute(baseTag, 'href')!);
     rewriteImportedUrls(importDoc, baseUrl, docUrl);
   }
-  if (dom5.predicates.hasAttr('target')(baseTag)) {
+  if (p.hasAttr('target')(baseTag)) {
     const baseTarget = dom5.getAttribute(baseTag, 'target')!;
-    for (const tag of dom5.queryAll(importDoc, matchers.baseTargetAppliesTo)) {
+    const tagsToTarget = dom5.queryAll(
+        importDoc,
+        p.AND(
+            p.OR(p.hasTagName('a'), p.hasTagName('form')),
+            p.NOT(p.hasAttr('target'))));
+    for (const tag of tagsToTarget) {
       dom5.setAttribute(tag, 'target', baseTarget);
     }
   }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -11,19 +11,17 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import * as path from 'path';
-import * as urlLib from 'url';
-const pathPosix = path.posix;
 import * as dom5 from 'dom5';
-import encodeString from './third_party/UglifyJS2/encode-string';
-
 import * as parse5 from 'parse5';
 import {ASTNode} from 'parse5';
-import constants from './constants';
+import * as urlLib from 'url';
+
 import * as astUtils from './ast-utils';
-import * as matchers from './matchers';
-import * as urlUtils from './url-utils';
 import {AssignedBundle, BundleManifest} from './bundle-manifest';
+import constants from './constants';
+import * as matchers from './matchers';
+import encodeString from './third_party/UglifyJS2/encode-string';
+import * as urlUtils from './url-utils';
 import {UrlString} from './url-utils';
 
 // TODO(usergenic): Revisit the organization of this module and *consider*
@@ -289,9 +287,7 @@ function _setImportedDomModuleAssetpaths(
   for (let i = 0, node: ASTNode; i < domModules.length; i++) {
     node = domModules[i];
     const assetPathUrl =
-        urlUtils.relativeUrl(
-            mainDocUrl, pathPosix.dirname(importUrl + '_') + '/') ||
-        './';
+        urlUtils.relativeUrl(mainDocUrl, urlUtils.debaseUrl(importUrl)) || './';
     dom5.setAttribute(node, 'assetpath', assetPathUrl);
   }
 }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -163,7 +163,7 @@ export async function inlineStylesheet(
 
   const media = dom5.getAttribute(cssLink, 'media');
   const resolvedStylesheetContent =
-      _rewriteCssTextBaseUrl(stylesheetContent, resolvedUrl, docUrl);
+      rewriteCssTextBaseUrl(stylesheetContent, resolvedUrl, docUrl);
   const styleNode = dom5.constructors.element('style');
 
   if (media) {
@@ -214,9 +214,9 @@ export function rewriteDocumentToEmulateBaseTag(
  */
 export function rewriteDocumentBaseUrl(
     ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
-  _rewriteElementAttrsBaseUrl(ast, oldBaseUrl, newBaseUrl);
-  _rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl);
-  _setDomModuleAssetpaths(ast, oldBaseUrl, newBaseUrl);
+  rewriteElementAttrsBaseUrl(ast, oldBaseUrl, newBaseUrl);
+  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl);
+  setDomModuleAssetpaths(ast, oldBaseUrl, newBaseUrl);
 }
 
 /**
@@ -224,7 +224,7 @@ export function rewriteDocumentBaseUrl(
  * have been rewritten based on the relationship of the old base url to the
  * new base url.
  */
-function _rewriteCssTextBaseUrl(
+function rewriteCssTextBaseUrl(
     cssText: string, oldBaseUrl: UrlString, newBaseUrl: UrlString): string {
   return cssText.replace(constants.URL, (match) => {
     let path = match.replace(/["']/g, '').slice(4, -1);
@@ -237,7 +237,7 @@ function _rewriteCssTextBaseUrl(
  * Find all element attributes which express urls and rewrite them so they
  * are based on the relationship of the old base url to the new base url.
  */
-function _rewriteElementAttrsBaseUrl(
+function rewriteElementAttrsBaseUrl(
     ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
   const nodes = dom5.queryAll(ast, matchers.urlAttrs);
   for (const node of nodes) {
@@ -246,7 +246,7 @@ function _rewriteElementAttrsBaseUrl(
       if (attrValue && !urlUtils.isTemplatedUrl(attrValue)) {
         let relUrl: UrlString;
         if (attr === 'style') {
-          relUrl = _rewriteCssTextBaseUrl(attrValue, oldBaseUrl, newBaseUrl);
+          relUrl = rewriteCssTextBaseUrl(attrValue, oldBaseUrl, newBaseUrl);
         } else {
           relUrl =
               urlUtils.rewriteHrefBaseUrl(attrValue, oldBaseUrl, newBaseUrl);
@@ -261,13 +261,13 @@ function _rewriteElementAttrsBaseUrl(
  * Find all urls in imported style nodes and rewrite them so they are based
  * on the relationship of the old base url to the new base url.
  */
-function _rewriteStyleTagsBaseUrl(
+function rewriteStyleTagsBaseUrl(
     ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
   const styleNodes = dom5.queryAll(
       ast, matchers.styleMatcher, undefined, dom5.childNodesIncludeTemplate);
   for (const node of styleNodes) {
     let styleText = dom5.getTextContent(node);
-    styleText = _rewriteCssTextBaseUrl(styleText, oldBaseUrl, newBaseUrl);
+    styleText = rewriteCssTextBaseUrl(styleText, oldBaseUrl, newBaseUrl);
     dom5.setTextContent(node, styleText);
   }
 }
@@ -276,7 +276,7 @@ function _rewriteStyleTagsBaseUrl(
  * Set the assetpath attribute of all imported dom-modules which don't yet
  * have them if the base urls are different.
  */
-function _setDomModuleAssetpaths(
+function setDomModuleAssetpaths(
     ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
   const domModules = dom5.queryAll(ast, matchers.domModuleWithoutAssetpath);
   for (let i = 0, node: ASTNode; i < domModules.length; i++) {

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -32,7 +32,7 @@ import {UrlString} from './url-utils';
  * Given an import document with a base tag, transform all of its URLs and set
  * link and form target attributes and remove the base tag.
  */
-export async function debaseDocument(docUrl: UrlString, importDoc: ASTNode) {
+export function debaseDocument(docUrl: UrlString, importDoc: ASTNode) {
   const baseTag = dom5.query(importDoc, matchers.base);
   const p = dom5.predicates;
   // If there's no base tag, there's nothing to do.

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -84,9 +84,6 @@ export const hiddenDiv: Matcher = predicates.AND(
     predicates.hasAttr('hidden'),
     predicates.hasAttr('by-polymer-bundler'));
 export const inHiddenDiv: Matcher = predicates.parentMatches(hiddenDiv);
-export const baseTargetAppliesTo: Matcher = predicates.AND(
-    predicates.OR(predicates.hasTagName('a'), predicates.hasTagName('form')),
-    predicates.NOT(predicates.hasAttr('target')));
 
 /**
  * TODO(usergenic): From garlicnation's PR comment - "This matcher needs to deal

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -84,6 +84,9 @@ export const hiddenDiv: Matcher = predicates.AND(
     predicates.hasAttr('hidden'),
     predicates.hasAttr('by-polymer-bundler'));
 export const inHiddenDiv: Matcher = predicates.parentMatches(hiddenDiv);
+export const baseTargetAppliesTo: Matcher = predicates.AND(
+    predicates.OR(predicates.hasTagName('a'), predicates.hasTagName('form')),
+    predicates.NOT(predicates.hasAttr('target')));
 
 /**
  * TODO(usergenic): From garlicnation's PR comment - "This matcher needs to deal

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -475,6 +475,24 @@ suite('Bundler', () => {
 
   suite('Regression Testing', () => {
 
+    test('Base tag emulation should not leak to other imports', async() => {
+      const doc = await bundle('test/html/base.html');
+      const clickMe = dom5.query(doc, preds.hasTextValue('CLICK ME'));
+      assert.ok(clickMe);
+
+      // The base target from `test/html/imports/base.html` should apply to the
+      // anchor tag in it.
+      assert.equal(dom5.getAttribute(clickMe!, 'target'), 'foo-frame');
+
+      const doNotClickMe =
+          dom5.query(doc, preds.hasTextValue('DO NOT CLICK ME'));
+      assert.ok(doNotClickMe);
+
+      // The base target from `test/html/imports/base.html` should NOT apply to
+      // the anchor tag in `test/html/imports/base-foo/sub-base.html`
+      assert.isFalse(dom5.hasAttribute(doNotClickMe!, 'target'));
+    });
+
     test('Complicated Ordering', async() => {
       // refer to
       // https://github.com/Polymer/polymer-bundler/tree/master/test/html/complicated/ordering.svg

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -33,82 +33,74 @@ suite('Bundler', () => {
   let bundler: Bundler;
   const inputPath = 'test/html/default.html';
 
-  function bundle(
-      inputPath: string, opts?: BundlerOptions): Promise<parse5.ASTNode> {
-    const bundlerOpts = opts || {};
-    if (!bundlerOpts.analyzer) {
-      bundlerOpts.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
-    }
-    bundler = new Bundler(bundlerOpts);
-    return bundler.bundle([inputPath])
-        .then((documents) => documents.get(inputPath)!.ast);
-  }
+  async function bundle(inputPath: string, opts?: BundlerOptions):
+      Promise<parse5.ASTNode> {
+        const bundlerOpts = opts || {};
+        if (!bundlerOpts.analyzer) {
+          bundlerOpts.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
+        }
+        bundler = new Bundler(bundlerOpts);
+        const documents = await bundler.bundle([inputPath]);
+        return documents.get(inputPath)!.ast;
+      }
 
   suite('Default Options', () => {
-    test('imports removed', () => {
+    test('imports removed', async() => {
       const imports = preds.AND(
           preds.hasTagName('link'),
           preds.hasAttrValue('rel', 'import'),
           preds.hasAttr('href'),
           preds.NOT(preds.hasAttrValue('type', 'css')));
-      return bundle(inputPath).then((doc) => {
-        assert.equal(dom5.queryAll(doc, imports).length, 0);
-      });
+      assert.equal(dom5.queryAll(await bundle(inputPath), imports).length, 0);
     });
 
-    test('imports were deduplicated', () => {
-      return bundle(inputPath).then((doc) => {
-        assert.equal(
-            dom5.queryAll(doc, preds.hasTagName('dom-module')).length, 1);
-      });
+    test('imports were deduplicated', async() => {
+      assert.equal(
+          dom5.queryAll(await bundle(inputPath), preds.hasTagName('dom-module'))
+              .length,
+          1);
     });
   });
 
-  test('svg is nested correctly', () => {
-    return bundle(inputPath).then((doc) => {
-      const svg = dom5.query(doc, matchers.template)!['content'].childNodes[1];
-      assert.equal(svg.childNodes!.filter(dom5.isElement).length, 6);
-    });
+  test('svg is nested correctly', async() => {
+    const svg =
+        dom5.query(await bundle(inputPath), matchers.template)!['content']
+            .childNodes[1];
+    assert.equal(svg.childNodes!.filter(dom5.isElement).length, 6);
   });
 
-  test('import bodies are in one hidden div', () => {
-    return bundle(inputPath).then((doc) => {
-      assert.equal(dom5.queryAll(doc, matchers.hiddenDiv).length, 1);
-    });
+  test('import bodies are in one hidden div', async() => {
+    assert.equal(
+        dom5.queryAll(await bundle(inputPath), matchers.hiddenDiv).length, 1);
   });
 
-  test('dom-modules have assetpath', () => {
+  test('dom-modules have assetpath', async() => {
     const assetpath = preds.AND(
         preds.hasTagName('dom-module'),
         preds.hasAttrValue('assetpath', 'imports/'));
-    return bundle(inputPath).then((doc) => {
-      assert.ok(dom5.query(doc, assetpath), 'assetpath set');
-    });
+    assert.ok(dom5.query(await bundle(inputPath), assetpath), 'assetpath set');
   });
 
-  test('output file is forced utf-8', () => {
+  test('output file is forced utf-8', async() => {
     const meta = preds.AND(
         preds.hasTagName('meta'), preds.hasAttrValue('charset', 'UTF-8'));
-    return bundle(inputPath).then((doc) => {
-      assert.ok(dom5.query(doc, meta));
-    });
+    assert.ok(dom5.query(await bundle(inputPath), meta));
   });
 
-  test('Handle <base> tag', () => {
+  test('Handle <base> tag', async() => {
     const span = preds.AND(
         preds.hasTagName('span'), preds.hasAttrValue('href', 'imports/hello'));
     const a = preds.AND(
         preds.hasTagName('a'),
         preds.hasAttrValue('href', 'imports/sub-base/sub-base.html'));
-    return bundle('test/html/base.html').then((doc) => {
-      const spanHref = dom5.query(doc, span);
-      assert.ok(spanHref);
-      const anchorRef = dom5.query(doc, a);
-      assert.ok(anchorRef);
-    });
+    const doc = await bundle('test/html/base.html');
+    const spanHref = dom5.query(doc, span);
+    assert.ok(spanHref);
+    const anchorRef = dom5.query(doc, a);
+    assert.ok(anchorRef);
   });
 
-  test('Imports in <body> are handled correctly', () => {
+  test('Imports in <body> are handled correctly', async() => {
     const importMatcher = preds.AND(
         preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
 
@@ -121,119 +113,110 @@ suite('Bundler', () => {
     const divExpected = preds.AND(
         preds.hasTagName('div'), preds.hasAttrValue('id', 'imported'));
 
-    return bundle('test/html/import-in-body.html').then(function(doc) {
-      const imports = dom5.queryAll(doc, importMatcher);
-      assert.equal(imports.length, 0);
-      const bodyContainer = dom5.query(doc, bodyContainerMatcher);
-      const scriptActual = dom5.query(doc, scriptExpected)!.parentNode;
-      const divActual = dom5.query(doc, divExpected)!.parentNode;
-      assert.equal(bodyContainer, scriptActual);
-      assert.equal(bodyContainer, divActual);
+    const doc = await bundle('test/html/import-in-body.html');
+    const imports = dom5.queryAll(doc, importMatcher);
+    assert.equal(imports.length, 0);
+    const bodyContainer = dom5.query(doc, bodyContainerMatcher);
+    const scriptActual = dom5.query(doc, scriptExpected)!.parentNode;
+    const divActual = dom5.query(doc, divExpected)!.parentNode;
+    assert.equal(bodyContainer, scriptActual);
+    assert.equal(bodyContainer, divActual);
+  });
+
+  test('Scripts are not inlined by default', async() => {
+    const scripts = dom5.queryAll(
+        await bundle('test/html/external.html'), matchers.externalJavascript);
+    assert.isAbove(scripts.length, 0, 'scripts were inlined');
+    scripts.forEach(function(s) {
+      assert.equal(dom5.getTextContent(s), '', 'script src should be empty');
     });
   });
 
-  test('Scripts are not inlined by default', () => {
-    const externalJS = matchers.externalJavascript;
-
-    return bundle('test/html/external.html').then((doc) => {
-      const scripts = dom5.queryAll(doc, externalJS);
-      assert.isAbove(scripts.length, 0, 'scripts were inlined');
-      scripts.forEach(function(s) {
-        assert.equal(dom5.getTextContent(s), '', 'script src should be empty');
-      });
-    });
-  });
-
-  test('Paths for import bodies are resolved correctly', () => {
+  test('Paths for import bodies are resolved correctly', async() => {
     const anchorMatcher = preds.hasTagName('a');
     const input = 'test/html/multiple-imports.html';
-    return bundle(input).then((doc) => {
-      const anchor = dom5.query(doc, anchorMatcher)!;
-      const href = dom5.getAttribute(anchor, 'href');
-      assert.equal(href, 'imports/target.html');
-    });
+    const anchor = dom5.query(await bundle(input), anchorMatcher)!;
+    const href = dom5.getAttribute(anchor, 'href');
+    assert.equal(href, 'imports/target.html');
   });
 
-  test('Spaces in paths are handled correctly', () => {
+  test('Spaces in paths are handled correctly', async() => {
     const input = 'test/html/spaces.html';
     const spacesMatcher = preds.AND(
         preds.hasTagName('dom-module'),
         preds.hasAttrValue('id', 'space-element'));
-    return bundle(input).then((doc) => {
-      const module = dom5.query(doc, spacesMatcher);
-      assert.ok(module);
-    });
+    const module = dom5.query(await bundle(input), spacesMatcher);
+    assert.ok(module);
   });
 
   suite('Script Ordering', () => {
-    test('Imports and scripts are ordered correctly', () => {
-      return bundle('test/html/order-test.html').then((doc) => {
-        const expectedOrder = [
-          'first-script',
-          'second-import-first-script',
-          'second-import-second-script',
-          'first-import-first-script',
-          'first-import-second-script',
-          'second-script',
-          'third-script'
-        ];
 
-        const expectedSrc = [
-          'order/first-script.js',
-          'order/second-import/first-script.js',
-          'order/second-import/second-script.js',
-          'order/first-import/first-script.js',
-          'order/first-import/second-script.js',
-          'order/second-script.js',
-          'order/third-script.js'
-        ];
+    test('Imports and scripts are ordered correctly', async() => {
+      const doc = await bundle('test/html/order-test.html');
 
-        const scripts = dom5.queryAll(doc, matchers.jsMatcher);
-        const actualOrder: Array<string> = [], actualSrc: Array<string> = [];
-        scripts.forEach(function(s) {
-          actualOrder.push(dom5.getAttribute(s, 'id')!);
-          actualSrc.push(dom5.getAttribute(s, 'src')!);
-        });
-        assert.deepEqual(
-            actualOrder, expectedOrder, 'order is not as expected');
-        assert.deepEqual(
-            actualSrc, expectedSrc, 'srcs are not preserved correctly');
+      const expectedOrder = [
+        'first-script',
+        'second-import-first-script',
+        'second-import-second-script',
+        'first-import-first-script',
+        'first-import-second-script',
+        'second-script',
+        'third-script'
+      ];
+
+      const expectedSrc = [
+        'order/first-script.js',
+        'order/second-import/first-script.js',
+        'order/second-import/second-script.js',
+        'order/first-import/first-script.js',
+        'order/first-import/second-script.js',
+        'order/second-script.js',
+        'order/third-script.js'
+      ];
+
+      const scripts = dom5.queryAll(doc, matchers.jsMatcher);
+      const actualOrder: Array<string> = [], actualSrc: Array<string> = [];
+      scripts.forEach(function(s) {
+        actualOrder.push(dom5.getAttribute(s, 'id')!);
+        actualSrc.push(dom5.getAttribute(s, 'src')!);
       });
+      assert.deepEqual(actualOrder, expectedOrder, 'order is not as expected');
+      assert.deepEqual(
+          actualSrc, expectedSrc, 'srcs are not preserved correctly');
     });
 
-    test('exhaustive script order testing', () => {
-      return bundle('test/html/script-order/index.html', {inlineScripts: true})
-          .then((doc) => {
-            assert(doc);
-            const serialized = parse5.serialize(doc);
-            const beforeLoc = serialized.indexOf('window.BeforeJs');
-            const afterLoc = serialized.indexOf('BeforeJs.value');
-            assert.isBelow(beforeLoc, afterLoc);
-          });
+    test('exhaustive script order testing', async() => {
+      const doc = await bundle(
+          'test/html/script-order/index.html', {inlineScripts: true});
+      assert(doc);
+      const serialized = parse5.serialize(doc);
+      const beforeLoc = serialized.indexOf('window.BeforeJs');
+      const afterLoc = serialized.indexOf('BeforeJs.value');
+      assert.isBelow(beforeLoc, afterLoc);
     });
 
-    test('Paths are correct when maintaining order', () => {
-      return bundle('test/html/recursion/import.html').then((doc) => {
-        assert(doc);
-        const scripts = dom5.queryAll(
-            doc, preds.AND(preds.hasTagName('script'), preds.hasAttr('src')));
-        scripts.forEach(function(s) {
-          const src = dom5.getAttribute(s, 'src')!;
-          assert.equal(
-              src.indexOf('../order'), 0, 'path should start with ../order');
-        });
-      });
+    test('Paths are correct when maintaining order', async() => {
+      const doc = await bundle('test/html/recursion/import.html');
+      assert(doc);
+      const scripts = dom5.queryAll(
+          doc, preds.AND(preds.hasTagName('script'), preds.hasAttr('src')));
+      for (const s of scripts) {
+        const src = dom5.getAttribute(s, 'src')!;
+        assert.equal(
+            src.indexOf('../order'), 0, 'path should start with ../order');
+      }
     });
   });
 
   suite('Redirect', () => {
-    test('Redirected paths load properly', () => {
+
+    test('Redirected paths load properly', async() => {
       const options = {
         redirects:
             ['chrome://imports/|test/html/imports/', 'biz://cool/|test/html']
       };
-      return bundle('test/html/custom-protocol.html', options)
-          .then((doc) => assert(doc));
+      const doc = await bundle('test/html/custom-protocol.html', options);
+      assert(doc);
     });
 
     // TODO(usergenic): Add tests here to demo common use case of alt domains.
@@ -251,13 +234,10 @@ suite('Bundler', () => {
 
     const excludes = ['test/html/imports/simple-import.html'];
 
-    test('Excluded imports are not inlined', () => {
-      const options = {excludes: excludes};
-
-      return bundle(inputPath, options).then((doc) => {
-        const imports = dom5.queryAll(doc, excluded);
-        assert.equal(imports.length, 1);
-      });
+    test('Excluded imports are not inlined', async() => {
+      const doc = await bundle(inputPath, {excludes: excludes});
+      const imports = dom5.queryAll(doc, excluded);
+      assert.equal(imports.length, 1);
     });
 
     const cssFromExclude = preds.AND(
@@ -265,236 +245,205 @@ suite('Bundler', () => {
         preds.hasAttrValue('rel', 'import'),
         preds.hasAttrValue('type', 'css'));
 
-    // TODO(ajo): Fix test with hydrolysis upgrades.
     test.skip(
         'Excluded imports are not inlined when behind a redirected URL.',
-        () => {
+        async() => {
           const options = {
             // TODO(usergenic): use non-redirected form of URL (?)
             excludes: ['test/html/imports/simple-import.html'],
             redirects: ['red://herring/at|test/html/imports']
           };
-          return bundle(
-                     path.resolve('test/html/custom-protocol-excluded.html'),
-                     options)
-              .then((doc) => {
-                const imports = dom5.queryAll(doc, htmlImport);
-                assert.equal(imports.length, 2);
-                const badCss = dom5.queryAll(doc, cssFromExclude);
-                assert.equal(badCss.length, 0);
-              });
+          const doc = await bundle(
+              path.resolve('test/html/custom-protocol-excluded.html'), options);
+          const imports = dom5.queryAll(doc, htmlImport);
+          assert.equal(imports.length, 2);
+          const badCss = dom5.queryAll(doc, cssFromExclude);
+          assert.equal(badCss.length, 0);
         });
 
-    test('Excluded imports with "Strip Excludes" are removed', () => {
+    test('Excluded imports with "Strip Excludes" are removed', async() => {
       const options = {stripExcludes: excludes};
-
-      return bundle(inputPath, options).then((doc) => {
-        const imports = dom5.queryAll(doc, excluded);
-        assert.equal(imports.length, 0);
-      });
+      const doc = await bundle(inputPath, options);
+      const imports = dom5.queryAll(doc, excluded);
+      assert.equal(imports.length, 0);
     });
 
-    test('Strip Excludes does not have to be exact', () => {
+    test('Strip Excludes does not have to be exact', async() => {
       const options = {stripExcludes: ['simple-import']};
-
-      return bundle(inputPath, options).then((doc) => {
-        const imports = dom5.queryAll(doc, excluded);
-        assert.equal(imports.length, 0);
-      });
+      const doc = await bundle(inputPath, options);
+      const imports = dom5.queryAll(doc, excluded);
+      assert.equal(imports.length, 0);
     });
 
-    test('Excluded comments are removed', () => {
+    test('Excluded comments are removed', async() => {
       const options = {stripComments: true};
-      return bundle('test/html/comments.html', options).then((doc) => {
-        const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
-        assert.equal(comments.length, 3);
-        const commentsExpected =
-            ['@license import 2', '@license import 1', '@license main'];
-        const commentsActual = comments.map(function(c) {
-          return dom5.getTextContent(c).trim();
-        });
-        assert.deepEqual(commentsExpected, commentsActual);
-      });
+      const doc = await bundle('test/html/comments.html', options);
+      const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
+      assert.equal(comments.length, 3);
+      const commentsExpected =
+          ['@license import 2', '@license import 1', '@license main'];
+      const commentsActual = comments.map((c) => dom5.getTextContent(c).trim());
+      assert.deepEqual(commentsExpected, commentsActual);
     });
 
-    test('Comments are kept by default', () => {
+    test('Comments are kept by default', async() => {
       const options = {stripComments: false};
-      return bundle('test/html/comments.html', options).then((doc) => {
-        const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
-        const expectedComments = [
-          '@license main',
-          '@license import 1',
-          'comment in import 1',
-          '@license import 2',
-          'comment in import 2',
-          'comment in main'
-        ];
-        const actualComments = comments.map(function(c) {
-          return dom5.getTextContent(c).trim();
-        });
-        assert.deepEqual(expectedComments, actualComments);
-      });
+      const doc = await bundle('test/html/comments.html', options);
+      const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
+      const expectedComments = [
+        '@license main',
+        '@license import 1',
+        'comment in import 1',
+        '@license import 2',
+        'comment in import 2',
+        'comment in main'
+      ];
+      const actualComments = comments.map((c) => dom5.getTextContent(c).trim());
+      assert.deepEqual(expectedComments, actualComments);
     });
 
-    test('Folder can be excluded', () => {
+    test('Folder can be excluded', async() => {
       const linkMatcher = preds.AND(
           preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
       const options = {excludes: ['test/html/imports/']};
-      return bundle('test/html/default.html', options).then((doc) => {
-        const links = dom5.queryAll(doc, linkMatcher);
-        // one duplicate import is removed.  default.html contains this
-        // duplication:
-        //     <link rel="import" href="imports/simple-import.html">
-        //     <link rel="import" href="imports/simple-import.html">
-        assert.equal(links.length, 1);
-      });
+      const doc = await bundle('test/html/default.html', options);
+      const links = dom5.queryAll(doc, linkMatcher);
+      // one duplicate import is removed.  default.html contains this
+      // duplication:
+      //     <link rel="import" href="imports/simple-import.html">
+      //     <link rel="import" href="imports/simple-import.html">
+      assert.equal(links.length, 1);
     });
   });
 
   suite('Inline Scripts', () => {
     const options = {inlineScripts: true};
 
-    test('All scripts are inlined', () => {
-      return bundle('test/html/external.html', options).then((doc) => {
-        const scripts = dom5.queryAll(doc, matchers.externalJavascript);
-        assert.equal(scripts.length, 0);
-      });
+    test('All scripts are inlined', async() => {
+      const doc = await bundle('test/html/external.html', options);
+      const scripts = dom5.queryAll(doc, matchers.externalJavascript);
+      assert.equal(scripts.length, 0);
     });
 
-    test('Remote scripts are kept', () => {
-      return bundle('test/html/scripts.html', options).then((doc) => {
-        const scripts = dom5.queryAll(doc, matchers.externalJavascript);
-        assert.equal(scripts.length, 1);
-        assert.equal(
-            dom5.getAttribute(scripts[0], 'src'),
-            'https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js');
-      });
+    test('Remote scripts are kept', async() => {
+      const doc = await bundle('test/html/scripts.html', options);
+      const scripts = dom5.queryAll(doc, matchers.externalJavascript);
+      assert.equal(scripts.length, 1);
+      assert.equal(
+          dom5.getAttribute(scripts[0], 'src'),
+          'https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js');
     });
 
-    test.skip('Absolute paths are correct for excluded links', () => {
+    test.skip('Absolute paths are correct for excluded links', async() => {
       const target = 'test/html/external.html';
       const options = {
         absPathPrefix: '/myapp/',
         inlineScripts: true,
         excludes: ['external/external.js']
       };
-      return bundle(target, options).then((doc) => {
-        const scripts = dom5.queryAll(doc, matchers.externalJavascript);
-        assert.equal(scripts.length, 1);
-        // TODO(usergenic): assert the src attribute is now
-        // /myapp/external/external.js
-      });
+      const doc = await bundle(target, options);
+      const scripts = dom5.queryAll(doc, matchers.externalJavascript);
+      assert.equal(scripts.length, 1);
+      // TODO(usergenic): assert the src attribute is now
+      // /myapp/external/external.js
     });
 
-    test('Escape inline <script>', () => {
-      return bundle('test/html/xss.html', options).then((doc) => {
-        const script = dom5.query(doc, matchers.inlineJavascript)!;
-        assert.include(
-            dom5.getTextContent(script),
-            'var b = 0<\\/script><script>alert(\'XSS\'); //2;',
-            'Inline <script> should be escaped');
-      });
+    test('Escape inline <script>', async() => {
+      const doc = await bundle('test/html/xss.html', options);
+      const script = dom5.query(doc, matchers.inlineJavascript)!;
+      assert.include(
+          dom5.getTextContent(script),
+          'var b = 0<\\/script><script>alert(\'XSS\'); //2;',
+          'Inline <script> should be escaped');
     });
 
-    test('Inlined Scripts are in the expected order', () => {
-      return bundle('test/html/reordered/in.html', options).then((doc) => {
-        const scripts = dom5.queryAll(doc, matchers.inlineJavascript)!;
-        const contents = scripts.map(function(script) {
-          return dom5.getTextContent(script);
-        });
-        assert.deepEqual(['"First"', '"Second"'], contents);
-      });
+    test('Inlined Scripts are in the expected order', async() => {
+      const doc = await bundle('test/html/reordered/in.html', options);
+      const scripts = dom5.queryAll(doc, matchers.inlineJavascript)!;
+      const contents = scripts.map((script) => dom5.getTextContent(script));
+      assert.deepEqual(['"First"', '"Second"'], contents);
     });
 
-    test('Firebase works inlined', () => {
-      return bundle('test/html/firebase.html', options).then((doc) => {
-        const scripts = dom5.queryAll(doc, matchers.inlineJavascript)!;
-        assert.equal(scripts.length, 1);
-        const idx = dom5.getTextContent(scripts[0]).indexOf('</script>');
-        assert(idx === -1, '/script found, should be escaped');
-      });
+    test('Firebase works inlined', async() => {
+      const doc = await bundle('test/html/firebase.html', options);
+      const scripts = dom5.queryAll(doc, matchers.inlineJavascript)!;
+      assert.equal(scripts.length, 1);
+      const idx = dom5.getTextContent(scripts[0]).indexOf('</script>');
+      assert(idx === -1, '/script found, should be escaped');
     });
   });
 
   suite('Inline CSS', () => {
+
     const options = {inlineCss: true};
 
-    test('All styles are inlined', () => {
-      return bundle(inputPath, options).then((doc) => {
-        const links = dom5.queryAll(doc, matchers.stylesheetImport);
-        const styles = dom5.queryAll(doc, matchers.styleMatcher);
-        assert.equal(links.length, 0);
-        assert.equal(styles.length, 2);
-      });
+    test('All styles are inlined', async() => {
+      const doc = await bundle(inputPath, options);
+      const links = dom5.queryAll(doc, matchers.stylesheetImport);
+      const styles = dom5.queryAll(doc, matchers.styleMatcher);
+      assert.equal(links.length, 0);
+      assert.equal(styles.length, 2);
     });
 
-    test('Inlined styles have proper paths', () => {
-      return bundle('test/html/inline-styles.html', options).then((doc) => {
-        const styles = dom5.queryAll(doc, matchers.styleMatcher);
-        assert.equal(styles.length, 2);
-        const content = dom5.getTextContent(styles[1]);
-        assert(content.search('imports/foo.jpg') > -1, 'path adjusted');
-        assert(content.search('@apply') > -1, '@apply kept');
-      });
+    test('Inlined styles have proper paths', async() => {
+      const doc = await bundle('test/html/inline-styles.html', options);
+      const styles = dom5.queryAll(doc, matchers.styleMatcher);
+      assert.equal(styles.length, 2);
+      const content = dom5.getTextContent(styles[1]);
+      assert(content.search('imports/foo.jpg') > -1, 'path adjusted');
+      assert(content.search('@apply') > -1, '@apply kept');
     });
 
-    test('Remote scripts, styles and media queries are preserved', () => {
+    test('Remote scripts, styles and media queries are preserved', async() => {
       const input = 'test/html/imports/remote-stylesheet.html';
-      return bundle(input, options).then((doc) => {
-        const links = dom5.queryAll(doc, matchers.externalStyle);
-        assert.equal(links.length, 1);
-        const styles = dom5.queryAll(doc, matchers.styleMatcher);
-        assert.equal(styles.length, 1);
-        assert.equal(
-            dom5.getAttribute(styles[0], 'media'), '(min-width: 800px)');
-      });
+      const doc = await bundle(input, options);
+      const links = dom5.queryAll(doc, matchers.externalStyle);
+      assert.equal(links.length, 1);
+      const styles = dom5.queryAll(doc, matchers.styleMatcher);
+      assert.equal(styles.length, 1);
+      assert.equal(dom5.getAttribute(styles[0], 'media'), '(min-width: 800px)');
     });
 
-    test.skip('Absolute paths are correct', () => {
+    test.skip('Absolute paths are correct', async() => {
       const root = path.resolve(inputPath, '../..');
       const options = {absPathPrefix: root, inlineCss: true};
-      return bundle('/test/html/default.html', options).then((doc) => {
-        const links = dom5.queryAll(doc, matchers.ALL_CSS_LINK);
-        assert.equal(links.length, 0);
-      });
+      const doc = await bundle('/test/html/default.html', options);
+      const links = dom5.queryAll(doc, matchers.ALL_CSS_LINK);
+      assert.equal(links.length, 0);
     });
 
-    test('Inlined Polymer styles are moved into the <template>', () => {
-      return bundle('test/html/default.html', options).then((doc) => {
-        const domModule = dom5.query(doc, preds.hasTagName('dom-module'))!;
-        assert(domModule);
-        const template = dom5.query(domModule, matchers.template)!;
-        assert(template);
-        const style =
-            dom5.queryAll(template.childNodes![0]!, matchers.styleMatcher);
-        assert.equal(style.length, 1);
-      });
+    test('Inlined Polymer styles are moved into the <template>', async() => {
+      const doc = await bundle('test/html/default.html', options);
+      const domModule = dom5.query(doc, preds.hasTagName('dom-module'))!;
+      assert(domModule);
+      const template = dom5.query(domModule, matchers.template)!;
+      assert(template);
+      const style =
+          dom5.queryAll(template.childNodes![0]!, matchers.styleMatcher);
+      assert.equal(style.length, 1);
     });
 
     test(
-        'Inlined Polymer styles will force a dom-module to have a template',
-        () => {
-          return bundle('test/html/inline-styles.html', options).then((doc) => {
-            const domModule = dom5.query(doc, preds.hasTagName('dom-module'))!;
-            assert(domModule);
-            const template = dom5.query(domModule, matchers.template)!;
-            assert(template);
-            const style =
-                dom5.query(template.childNodes![0]!, matchers.styleMatcher);
-            assert(style);
-          });
+        'Inlined Polymer styles force dom-module to have template', async() => {
+          const doc = await bundle('test/html/inline-styles.html', options);
+          const domModule = dom5.query(doc, preds.hasTagName('dom-module'))!;
+          assert(domModule);
+          const template = dom5.query(domModule, matchers.template)!;
+          assert(template);
+          const style =
+              dom5.query(template.childNodes![0]!, matchers.styleMatcher);
+          assert(style);
         });
   });
 
   suite.skip('Add import', () => {
     const options = {addedImports: ['imports/comment-in-import.html']};
-    test('added import is added to bundled doc', () => {
-      return bundle('test/html/default.html', options).then((doc) => {
-        assert(doc);
-        const hasAddedImport =
-            preds.hasAttrValue('href', 'imports/comment-in-import.html');
-        assert.equal(dom5.queryAll(doc, hasAddedImport).length, 1);
-      });
+    test('added import is added to bundled doc', async() => {
+      const doc = await bundle('test/html/default.html', options);
+      assert(doc);
+      const hasAddedImport =
+          preds.hasAttrValue('href', 'imports/comment-in-import.html');
+      assert.equal(dom5.queryAll(doc, hasAddedImport).length, 1);
     });
   });
 
@@ -503,94 +452,90 @@ suite('Bundler', () => {
   // support inputUrl?  Tese don't prove anything about the doc production
   // itself or how it is effected.  Needs resolution.
   suite('Input URL', () => {
+
     const options = {inputUrl: 'test/html/default.html'};
 
-    test.skip('inputURL is used instead of argument to process', () => {
-      return bundle('flibflabfloom!', options).then((doc) => {
-        assert(doc);
-      });
+    test.skip('inputURL is used instead of argument to process', async() => {
+      const doc = await bundle('flibflabfloom!', options);
+      assert(doc);
     });
 
-    test.skip('gulp-vulcanize invocation with absPathPrefix', () => {
+    test.skip('gulp-vulcanize invocation with absPathPrefix', async() => {
       const options = {
         abspath: path.resolve('test/html'),
         inputUrl: '/default.html'
       };
 
-      return bundle(
-                 'C:\\Users\\PolymerBundlerTester\\polymer-bundler\\test\\html\\default.html',
-                 options)
-          .then((doc) => assert(doc));
+      const doc = await bundle(
+          'C:\\Users\\PolymerBundlerTester\\polymer-bundler\\test\\html\\default.html',
+          options);
+      assert(doc);
     });
   });
 
   suite('Regression Testing', () => {
-    test('Complicated Ordering', () => {
+
+    test('Complicated Ordering', async() => {
       // refer to
       // https://github.com/Polymer/polymer-bundler/tree/master/test/html/complicated/ordering.svg
       // for visual reference on the document structure for this example
-      return bundle('test/html/complicated/A.html', {inlineScripts: true})
-          .then((doc) => {
-            assert(doc);
-            const expected = ['A1', 'C', 'E', 'B', 'D', 'A2'];
-            const scripts = dom5.queryAll(doc, matchers.jsMatcher);
-            const contents = scripts.map(function(s) {
-              return dom5.getTextContent(s).trim();
-            });
-            assert.deepEqual(contents, expected);
-          });
-    });
-
-    test('Assetpath rewriting', () => {
-      return bundle('test/html/path-rewriting/src/app-main/app-main.html')
-          .then((doc) => {
-            assert(doc);
-            const domModules =
-                dom5.queryAll(doc, preds.hasTagName('dom-module'));
-            const assetpaths = domModules.map(
-                (domModule) =>
-                    [dom5.getAttribute(domModule, 'id'),
-                     dom5.getAttribute(domModule, 'assetpath')]);
-            assert.deepEqual(assetpaths, [
-              ['test-c', '../../bower_components/test-component/'],
-              ['test-b', '../../bower_components/test-component/src/elements/'],
-              ['test-a', '../../bower_components/test-component/'],
-
-              // We don't need an assetpath on app-main because its not been
-              // moved/inlined from another location.
-              ['app-main', null]
-            ]);
-          });
-    });
-
-    test('Entrypoint body content should not be wrapped by bundler', () => {
-      return bundle('test/html/default.html').then((doc) => {
-        assert(doc);
-        const myElement = dom5.query(doc, preds.hasTagName('my-element'));
-        assert(myElement);
-        assert(preds.NOT(preds.parentMatches(
-            preds.hasAttr('by-polymer-bundler')))(<parse5.ASTNode>myElement));
+      const doc =
+          await bundle('test/html/complicated/A.html', {inlineScripts: true});
+      assert(doc);
+      const expected = ['A1', 'C', 'E', 'B', 'D', 'A2'];
+      const scripts = dom5.queryAll(doc, matchers.jsMatcher);
+      const contents = scripts.map(function(s) {
+        return dom5.getTextContent(s).trim();
       });
+      assert.deepEqual(contents, expected);
     });
 
-    test.skip('Imports in templates should not inline', () => {
-      return bundle('test/html/inside-template.html').then((doc) => {
-        const importMatcher = preds.AND(
-            preds.hasTagName('link'),
-            preds.hasAttrValue('rel', 'import'),
-            preds.hasAttr('href'));
-        const externalScriptMatcher = preds.AND(
-            preds.hasTagName('script'),
-            preds.hasAttrValue('src', 'external/external.js'));
-        assert(doc);
-        const imports = dom5.queryAll(doc, importMatcher);
-        assert.equal(imports.length, 1, 'import in template was inlined');
-        const unexpectedScript = dom5.query(doc, externalScriptMatcher);
-        assert.equal(
-            unexpectedScript,
-            null,
-            'script in external.html should not be present');
-      });
+    test('Assetpath rewriting', async() => {
+      const doc =
+          await bundle('test/html/path-rewriting/src/app-main/app-main.html');
+      assert(doc);
+      const domModules = dom5.queryAll(doc, preds.hasTagName('dom-module'));
+      const assetpaths = domModules.map(
+          (domModule) =>
+              [dom5.getAttribute(domModule, 'id'),
+               dom5.getAttribute(domModule, 'assetpath')]);
+      assert.deepEqual(assetpaths, [
+        ['test-c', '../../bower_components/test-component/'],
+        ['test-b', '../../bower_components/test-component/src/elements/'],
+        ['test-a', '../../bower_components/test-component/'],
+
+        // We don't need an assetpath on app-main because its not been
+        // moved/inlined from another location.
+        ['app-main', null]
+      ]);
+    });
+
+    test('Entrypoint body content should not be wrapped', async() => {
+      const doc = await bundle('test/html/default.html');
+      assert(doc);
+      const myElement = dom5.query(doc, preds.hasTagName('my-element'));
+      assert(myElement);
+      assert(preds.NOT(preds.parentMatches(
+          preds.hasAttr('by-polymer-bundler')))(<parse5.ASTNode>myElement));
+    });
+
+    test.skip('Imports in templates should not inline', async() => {
+      const doc = await bundle('test/html/inside-template.html');
+      const importMatcher = preds.AND(
+          preds.hasTagName('link'),
+          preds.hasAttrValue('rel', 'import'),
+          preds.hasAttr('href'));
+      const externalScriptMatcher = preds.AND(
+          preds.hasTagName('script'),
+          preds.hasAttrValue('src', 'external/external.js'));
+      assert(doc);
+      const imports = dom5.queryAll(doc, importMatcher);
+      assert.equal(imports.length, 1, 'import in template was inlined');
+      const unexpectedScript = dom5.query(doc, externalScriptMatcher);
+      assert.equal(
+          unexpectedScript,
+          null,
+          'script in external.html should not be present');
     });
   });
 });

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -555,7 +555,10 @@ suite('Bundler', () => {
               ['test-c', '../../bower_components/test-component/'],
               ['test-b', '../../bower_components/test-component/src/elements/'],
               ['test-a', '../../bower_components/test-component/'],
-              ['app-main', './']
+
+              // We don't need an assetpath on app-main because its not been
+              // moved/inlined from another location.
+              ['app-main', null]
             ]);
           });
     });

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -94,13 +94,13 @@ suite('Bundler', () => {
     });
   });
 
-  test.skip('Handle <base> tag', () => {
+  test('Handle <base> tag', () => {
     const span = preds.AND(
         preds.hasTagName('span'), preds.hasAttrValue('href', 'imports/hello'));
     const a = preds.AND(
         preds.hasTagName('a'),
         preds.hasAttrValue('href', 'imports/sub-base/sub-base.html'));
-    return bundle('html/base.html').then((doc) => {
+    return bundle('test/html/base.html').then((doc) => {
       const spanHref = dom5.query(doc, span);
       assert.ok(spanHref);
       const anchorRef = dom5.query(doc, a);

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -122,7 +122,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.rebaseDocument(importDocPath, ast);
+      importUtils.debaseDocument(importDocPath, ast);
       importUtils.rewriteImportedUrls(ast, importDocPath, mainDocPath);
 
       const actual = parse5.serialize(ast);
@@ -155,7 +155,7 @@ suite('import-utils', () => {
         </body></html>`;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.rebaseDocument(importDocPath, ast);
+      importUtils.debaseDocument(importDocPath, ast);
       importUtils.rewriteImportedUrls(ast, importDocPath, mainDocPath);
 
       const actual = parse5.serialize(ast);
@@ -176,7 +176,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.rebaseDocument(importDocPath, ast);
+      importUtils.debaseDocument(importDocPath, ast);
       importUtils.rewriteImportedUrls(ast, importDocPath, mainDocPath);
 
       const actual = parse5.serialize(ast);

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -57,10 +57,9 @@ suite('import-utils', () => {
         }
       `;
 
-      const _rewriteImportedStyleTextUrls =
-          importUtils.__get__('_rewriteImportedStyleTextUrls');
-      const actual =
-          _rewriteImportedStyleTextUrls(importDocPath, mainDocPath, css);
+      const _rewriteCssTextBaseUrl =
+          importUtils.__get__('_rewriteCssTextBaseUrl');
+      const actual = _rewriteCssTextBaseUrl(css, importDocPath, mainDocPath);
       assert.equal(actual, expected);
     });
 
@@ -90,7 +89,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(html);
-      importUtils.rewriteImportedUrls(ast, importDocPath, mainDocPath);
+      importUtils.rewriteDocumentBaseUrl(ast, importDocPath, mainDocPath);
 
       const actual = parse5.serialize(ast);
       assert.equal(stripSpace(actual), stripSpace(expected), 'relative');
@@ -105,7 +104,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(base);
-      importUtils.rewriteImportedUrls(ast, importDocPath, mainDocPath);
+      importUtils.rewriteDocumentBaseUrl(ast, importDocPath, mainDocPath);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(base), 'templated urls');

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -57,9 +57,9 @@ suite('import-utils', () => {
         }
       `;
 
-      const _rewriteCssTextBaseUrl =
-          importUtils.__get__('_rewriteCssTextBaseUrl');
-      const actual = _rewriteCssTextBaseUrl(css, importDocPath, mainDocPath);
+      const rewriteCssTextBaseUrl =
+          importUtils.__get__('rewriteCssTextBaseUrl');
+      const actual = rewriteCssTextBaseUrl(css, importDocPath, mainDocPath);
       assert.equal(actual, expected);
     });
 

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -141,7 +141,7 @@ suite('import-utils', () => {
         </body></html>`;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.debaseDocument('the/doc/url', ast);
+      importUtils.rewriteDocumentToEmulateBaseTag('the/doc/url', ast);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(expectedBase), 'base');
@@ -175,7 +175,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.debaseDocument('the/doc/url', ast);
+      importUtils.rewriteDocumentToEmulateBaseTag('the/doc/url', ast);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(expectedBase), 'base');
@@ -203,7 +203,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.debaseDocument('the/doc/url', ast);
+      importUtils.rewriteDocumentToEmulateBaseTag('the/doc/url', ast);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -26,23 +26,26 @@ const assert = chai.assert;
 
 suite('URL Utils', () => {
 
-  suite('debaseUrl', () => {
+  suite('stripUrlFileSearchAndHash', () => {
 
     test('Strips "file.html" basename off url', () => {
       assert.equal(
-          urlUtils.debaseUrl('https://example.com/path/to/file.html'),
+          urlUtils.stripUrlFileSearchAndHash(
+              'https://example.com/path/to/file.html'),
           'https://example.com/path/to/');
     });
 
     test('Strips "something?a=b&c=d" basename and search off url', () => {
       assert.equal(
-          urlUtils.debaseUrl('https://example.com/path/to/something?a=b&c=d'),
+          urlUtils.stripUrlFileSearchAndHash(
+              'https://example.com/path/to/something?a=b&c=d'),
           'https://example.com/path/to/');
     });
 
     test('Handles relative paths', () => {
       assert.equal(
-          urlUtils.debaseUrl('relative/path/to/file'), 'relative/path/to/');
+          urlUtils.stripUrlFileSearchAndHash('relative/path/to/file'),
+          'relative/path/to/');
     });
   });
 

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -42,6 +42,13 @@ suite('URL Utils', () => {
           'https://example.com/path/to/');
     });
 
+    test('Strips "#some-hash-value" off url', () => {
+      assert.equal(
+          urlUtils.stripUrlFileSearchAndHash(
+              'https://example.com/path/#some-hash-value'),
+          'https://example.com/path/');
+    });
+
     test('Handles relative paths', () => {
       assert.equal(
           urlUtils.stripUrlFileSearchAndHash('relative/path/to/file'),

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -63,7 +63,7 @@ suite('URL Utils', () => {
 
     function testRewrite(val: string, expected: string, msg?: string) {
       const actual =
-          urlUtils.rewriteImportedRelPath(importDocPath, mainDocPath, val);
+          urlUtils.rewriteHrefBaseUrl(val, importDocPath, mainDocPath);
       assert.equal(actual, expected, msg);
     }
 

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -26,6 +26,26 @@ const assert = chai.assert;
 
 suite('URL Utils', () => {
 
+  suite('debaseUrl', () => {
+
+    test('Strips "file.html" basename off url', () => {
+      assert.equal(
+          urlUtils.debaseUrl('https://example.com/path/to/file.html'),
+          'https://example.com/path/to/');
+    });
+
+    test('Strips "something?a=b&c=d" basename and search off url', () => {
+      assert.equal(
+          urlUtils.debaseUrl('https://example.com/path/to/something?a=b&c=d'),
+          'https://example.com/path/to/');
+    });
+
+    test('Handles relative paths', () => {
+      assert.equal(
+          urlUtils.debaseUrl('relative/path/to/file'), 'relative/path/to/');
+    });
+  });
+
   suite('Rewrite imported relative paths', () => {
 
     const importDocPath = '/foo/bar/my-element/index.html';
@@ -98,8 +118,8 @@ suite('URL Utils', () => {
     });
 
     // TODO(usergenic): Update resolveUrl to interpret scheme-less URLs the
-    // same way browsers do, where '//' prefix implies preserved scheme and the
-    // first path segment is actually the host.
+    // same way browsers do, where '//' prefix implies preserved scheme and
+    // the first path segment is actually the host.
     test.skip('Scheme-less URLs should be interpreted as browsers do', () => {
       assert.equal(urlUtils.relativeUrl('//a/b', '/c/d'), 'c/d');
       assert.equal(urlUtils.relativeUrl('/a/b', '//c/d'), '//c/d');

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -30,6 +30,19 @@ const sharedRelativeUrlProperties =
 export type UrlString = string;
 
 /**
+ * Returns a URL with the basename removed from the pathname.  Strips the
+ * search off of the URL as well, since it will not apply.
+ */
+export function debaseUrl(href: UrlString): UrlString {
+  const u = url.parse(href);
+  if (typeof u.pathname === 'string') {
+    u.pathname = path.dirname(u.pathname + '_').replace(/_$/, '') + '/';
+  }
+  u.search = undefined;
+  return url.format(u);
+}
+
+/**
  * Returns true if the href is an absolute path.
  */
 export function isAbsolutePath(href: UrlString): boolean {
@@ -91,17 +104,4 @@ export function rewriteImportedRelPath(
         {pathname: pathname, search: parsedTo.search, hash: parsedTo.hash});
   }
   return absUrl;
-}
-
-/**
- * Returns a URL with the basename removed from the pathname.  Strips the
- * search off of the URL as well, since it will not apply.
- */
-export function debaseUrl(href: UrlString): UrlString {
-  const u = url.parse(href);
-  if (typeof u.pathname === 'string') {
-    u.pathname = path.dirname(u.pathname + '_').replace(/_$/, '') + '/';
-  }
-  u.search = undefined;
-  return url.format(u);
 }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -33,12 +33,13 @@ export type UrlString = string;
  * Returns a URL with the basename removed from the pathname.  Strips the
  * search off of the URL as well, since it will not apply.
  */
-export function debaseUrl(href: UrlString): UrlString {
+export function stripUrlFileSearchAndHash(href: UrlString): UrlString {
   const u = url.parse(href);
-  if (typeof u.pathname === 'string') {
+  if (u.pathname !== undefined) {
     u.pathname = path.dirname(u.pathname + '_').replace(/_$/, '') + '/';
   }
   u.search = undefined;
+  u.hash = undefined;
   return url.format(u);
 }
 

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -37,7 +37,10 @@ export function stripUrlFileSearchAndHash(href: UrlString): UrlString {
   const u = url.parse(href);
   // Using != so tests for null AND undefined
   if (u.pathname != null) {
-    u.pathname = path.dirname(u.pathname + '_').replace(/_$/, '') + '/';
+    // Suffix path with `_` so that `/a/b/` is treated as `/a/b/_` and that
+    // `path.dirname()` returns `/a/b` because it would otherwise return `/a`
+    // incorrectly.
+    u.pathname = path.dirname(u.pathname + '_') + '/';
   }
   // Assigning to undefined because TSC says type of these is
   // `string | undefined` as opposed to `string | null`

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -92,3 +92,16 @@ export function rewriteImportedRelPath(
   }
   return absUrl;
 }
+
+/**
+ * Returns a URL with the basename removed from the pathname.  Strips the
+ * search off of the URL as well, since it will not apply.
+ */
+export function debaseUrl(href: UrlString): UrlString {
+  const u = url.parse(href);
+  if (typeof u.pathname === 'string') {
+    u.pathname = path.dirname(u.pathname + '_').replace(/_$/, '') + '/';
+  }
+  u.search = undefined;
+  return url.format(u);
+}

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -35,9 +35,12 @@ export type UrlString = string;
  */
 export function stripUrlFileSearchAndHash(href: UrlString): UrlString {
   const u = url.parse(href);
-  if (u.pathname !== undefined) {
+  // Using != so tests for null AND undefined
+  if (u.pathname != null) {
     u.pathname = path.dirname(u.pathname + '_').replace(/_$/, '') + '/';
   }
+  // Assigning to undefined because TSC says type of these is
+  // `string | undefined` as opposed to `string | null`
   u.search = undefined;
   u.hash = undefined;
   return url.format(u);

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -91,17 +91,16 @@ export function relativeUrl(fromUri: UrlString, toUri: UrlString): UrlString {
 }
 
 /**
- * Modifies an href by the relative difference between the `mainDocUrl` and
- * `importUrl` which is the location of the imported document containing the
- * href.
+ * Modifies an href by the relative difference between the old base url and
+ * the new base url.
  */
-export function rewriteImportedRelPath(
-    importUrl: UrlString, mainDocUrl: UrlString, href: UrlString): UrlString {
+export function rewriteHrefBaseUrl(
+    href: UrlString, oldBaseUrl: UrlString, newBaseUrl: UrlString): UrlString {
   if (isAbsolutePath(href)) {
     return href;
   }
-  const absUrl = url.resolve(importUrl, href);
-  const parsedFrom = url.parse(mainDocUrl);
+  const absUrl = url.resolve(oldBaseUrl, href);
+  const parsedFrom = url.parse(newBaseUrl);
   const parsedTo = url.parse(absUrl);
   if (parsedFrom.protocol === parsedTo.protocol &&
       parsedFrom.host === parsedTo.host) {

--- a/test/html/imports/base-foo/sub-base.html
+++ b/test/html/imports/base-foo/sub-base.html
@@ -1,3 +1,4 @@
 <base href="../../imports/">
 <link rel="import" href="super-base.html">
 <span href="hello">From Sub-Base!</span>
+<a href="lame-page.html">DO NOT CLICK ME</a>

--- a/test/html/imports/base-foo/sub-base.html
+++ b/test/html/imports/base-foo/sub-base.html
@@ -1,3 +1,3 @@
-<base href="../../imports">
+<base href="../../imports/">
 <link rel="import" href="super-base.html">
 <span href="hello">From Sub-Base!</span>

--- a/test/html/imports/base.html
+++ b/test/html/imports/base.html
@@ -1,2 +1,2 @@
-<base href="base-foo">
+<base href="base-foo/">
 <link rel="import" href="sub-base.html">

--- a/test/html/imports/base.html
+++ b/test/html/imports/base.html
@@ -1,2 +1,3 @@
-<base href="base-foo/">
+<base href="base-foo/" target="foo-frame">
 <link rel="import" href="sub-base.html">
+<a href="cool-page.html">CLICK ME</a>


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Handle `<base href="...">` values correctly when resolving imports.
 - Apply `<base target="...">` to links and forms in the same document as appropriate.
