### PR TITLE
Dedup license comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Handle `<base href="...">` values correctly when inlining imports.
 - Apply `<base target="...">` to links and forms in the same document as
   appropriate.
+- License comments are deduplicated properly now.
 
 ## 2.0.0-pre.5 - 2017-02-14
 - Handle base tags when resolving the dependency graph of imports.

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -109,16 +109,21 @@ export function siblingsAfter(node: ASTNode): ASTNode[] {
  * deduplicate them and prepend them in document's head.
  */
 export function stripComments(document: ASTNode) {
-  // Use of a Map keyed by comment text enables deduplication.
-  const comments: Map<string, ASTNode> = new Map();
-  dom5.nodeWalkAll(document, dom5.isCommentNode).forEach((comment: ASTNode) => {
-    comments.set(comment.data || '', comment);
-    removeElementAndNewline(comment);
-  });
-  const head = dom5.query(document, matchers.head);
-  for (const comment of comments.values()) {
-    if (isLicenseComment(comment)) {
-      prepend(head || document, comment);
+  const uniqueLicenseTexts = new Set<string>();
+  const licenseComments: ASTNode[] = [];
+  for (const comment of dom5.nodeWalkAll(document, dom5.isCommentNode)) {
+    // Make whitespace uniform so we can deduplicate based on actual content.
+    const commentText = (comment.data || '').replace(/\s+/g, ' ').trim();
+
+    if (isLicenseComment(comment) && !uniqueLicenseTexts.has(commentText)) {
+      uniqueLicenseTexts.add(commentText);
+      licenseComments.push(comment);
     }
+
+    removeElementAndNewline(comment);
+  }
+  const prependTarget = dom5.query(document, matchers.head) || document;
+  for (const comment of licenseComments.reverse()) {
+    prepend(prependTarget, comment);
   }
 }

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -279,27 +279,37 @@ suite('Bundler', () => {
       const options = {stripComments: true};
       const doc = await bundle('test/html/comments.html', options);
       const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
-      assert.equal(comments.length, 3);
-      const commentsExpected =
-          ['@license import 2', '@license import 1', '@license main'];
+      assert.equal(comments.length, 4);
+      const commentsExpected = [
+        '@license common',
+        '@license main',
+        '@license import 1',
+        '@license import 2'
+      ];
       const commentsActual = comments.map((c) => dom5.getTextContent(c).trim());
-      assert.deepEqual(commentsExpected, commentsActual);
+      assert.deepEqual(commentsActual, commentsExpected);
     });
 
     test('Comments are kept by default', async() => {
       const options = {stripComments: false};
       const doc = await bundle('test/html/comments.html', options);
       const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
+
+      // NOTE: Explicitly not trimming the expected comments to ensure we keep
+      // the test fixtures with the same whitespace they currently have.
       const expectedComments = [
-        '@license main',
-        '@license import 1',
-        'comment in import 1',
-        '@license import 2',
-        'comment in import 2',
-        'comment in main'
+        ' @license common ',
+        ' @license main ',
+        '\n@license common\n',
+        ' @license import 1 ',
+        '\n  @license common\n  ',
+        ' comment in import 1 ',
+        ' @license import 2 ',
+        ' comment in import 2 ',
+        ' comment in main '
       ];
-      const actualComments = comments.map((c) => dom5.getTextContent(c).trim());
-      assert.deepEqual(expectedComments, actualComments);
+      const actualComments = comments.map((c) => dom5.getTextContent(c));
+      assert.deepEqual(actualComments, expectedComments);
     });
 
     test('Folder can be excluded', async() => {

--- a/test/html/comments.html
+++ b/test/html/comments.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- @license common -->
 <!-- @license main -->
 <html lang="en">
 <head>

--- a/test/html/imports/comment-in-import.html
+++ b/test/html/imports/comment-in-import.html
@@ -1,3 +1,6 @@
+<!--
+@license common
+-->
 <!-- @license import 1 -->
 <link rel="import" href="sub/second.html">
 <!-- comment in import 1 -->

--- a/test/html/imports/sub/second.html
+++ b/test/html/imports/sub/second.html
@@ -1,0 +1,3 @@
+  <!--
+  @license common
+  -->


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - There were cases in my builds I saw tons of duplicated licenses.
 - I wanted to fix that.
 - It was due to whitespace issues mostly.
 - I had to monkey with the strip comments code because #427 and have a separate PR for that.