### PR TITLE
Dont strip server-side-includes when stripping comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Apply `<base target="...">` to links and forms in the same document as
   appropriate.
 - License comments are deduplicated properly now.
-- SSI comments are no longer stripped.
+- Server-Side Include comments `<!--# ... -->` are no longer stripped.
 
 ## 2.0.0-pre.5 - 2017-02-14
 - Handle base tags when resolving the dependency graph of imports.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Apply `<base target="...">` to links and forms in the same document as
   appropriate.
 - License comments are deduplicated properly now.
+- SSI comments are no longer stripped.
 
 ## 2.0.0-pre.5 - 2017-02-14
 - Handle base tags when resolving the dependency graph of imports.

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -69,7 +69,7 @@ export function isLicenseComment(node: ASTNode): boolean {
  * <!--#directive ...-->
  */
 export function isServerSideIncludeComment(node: ASTNode): boolean {
-  return !!node.data && !!node.data.match(/^#\w/);
+  return !!node.data && !!node.data.match(/^#/);
 }
 
 /**

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -65,6 +65,14 @@ export function isLicenseComment(node: ASTNode): boolean {
 }
 
 /**
+ * Return true if node is a comment node that is a server-side-include.  E.g.
+ * <!--#directive ...-->
+ */
+export function isServerSideIncludeComment(node: ASTNode): boolean {
+  return !!node.data && !!node.data.match(/^#\w/);
+}
+
+/**
  * Inserts the node as the first child of the parent.
  * TODO(usergenic): Migrate this code to polymer/dom5
  */
@@ -112,6 +120,10 @@ export function stripComments(document: ASTNode) {
   const uniqueLicenseTexts = new Set<string>();
   const licenseComments: ASTNode[] = [];
   for (const comment of dom5.nodeWalkAll(document, dom5.isCommentNode)) {
+    if (isServerSideIncludeComment(comment)) {
+      continue;
+    }
+
     // Make whitespace uniform so we can deduplicate based on actual content.
     const commentText = (comment.data || '').replace(/\s+/g, ' ').trim();
 

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -279,8 +279,9 @@ suite('Bundler', () => {
       const options = {stripComments: true};
       const doc = await bundle('test/html/comments.html', options);
       const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
-      assert.equal(comments.length, 4);
+      assert.equal(comments.length, 5);
       const commentsExpected = [
+        '#important server-side include business',
         '@license common',
         '@license main',
         '@license import 1',
@@ -298,6 +299,8 @@ suite('Bundler', () => {
       // NOTE: Explicitly not trimming the expected comments to ensure we keep
       // the test fixtures with the same whitespace they currently have.
       const expectedComments = [
+        '#important server-side include business ',
+        '# not a server-side include ',
         ' @license common ',
         ' @license main ',
         '\n@license common\n',

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -301,6 +301,7 @@ suite('Bundler', () => {
       const expectedComments = [
         '#important server-side include business ',
         '# this could be a server-side include too ',
+        ' #this is not a server-side include ',
         ' @license common ',
         ' @license main ',
         '\n@license common\n',

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -279,9 +279,9 @@ suite('Bundler', () => {
       const options = {stripComments: true};
       const doc = await bundle('test/html/comments.html', options);
       const comments = dom5.nodeWalkAll(doc, dom5.isCommentNode);
-      assert.equal(comments.length, 5);
       const commentsExpected = [
         '#important server-side include business',
+        '# this could be a server-side include too',
         '@license common',
         '@license main',
         '@license import 1',
@@ -300,7 +300,7 @@ suite('Bundler', () => {
       // the test fixtures with the same whitespace they currently have.
       const expectedComments = [
         '#important server-side include business ',
-        '# not a server-side include ',
+        '# this could be a server-side include too ',
         ' @license common ',
         ' @license main ',
         '\n@license common\n',

--- a/test/html/comments.html
+++ b/test/html/comments.html
@@ -1,5 +1,6 @@
 <!--#important server-side include business -->
 <!--# this could be a server-side include too -->
+<!-- #this is not a server-side include -->
 <!DOCTYPE html>
 <!-- @license common -->
 <!-- @license main -->

--- a/test/html/comments.html
+++ b/test/html/comments.html
@@ -1,3 +1,5 @@
+<!--#important server-side include business -->
+<!--# not a server-side include -->
 <!DOCTYPE html>
 <!-- @license common -->
 <!-- @license main -->

--- a/test/html/comments.html
+++ b/test/html/comments.html
@@ -1,5 +1,5 @@
 <!--#important server-side include business -->
-<!--# not a server-side include -->
+<!--# this could be a server-side include too -->
 <!DOCTYPE html>
 <!-- @license common -->
 <!-- @license main -->


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Fixes bug #427 where comments like `<!--#include important stuff -->` are stripped.
