### PR TITLE
Updated CHANGELOG for 2.0.0-pre.6 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## 2.0.0-pre.6 - 2017-02-17
 - Handle `<base href="...">` values correctly when inlining imports.
 - Apply `<base target="...">` to links and forms in the same document as
   appropriate.


### PR DESCRIPTION
Exciting updates for 2.0.0-pre.6
 - Handle `<base href="...">` values correctly when inlining imports.
 - Apply `<base target="...">` to links and forms in the same document as
   appropriate.
 - License comments are deduplicated properly now.
 - Server-Side Include comments `<!--# ... -->` are no longer stripped.
 - Fixed a bug where element attributes inside `<template>` tags were not
   being rewritten when html imports were inlined. #430 
 - [x] CHANGELOG.md has been updated
