### PR TITLE
getImplicitExcludes: Don't attempt to load excluded JS scripts.

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -419,8 +419,8 @@ Vulcan.prototype = {
     var loader = buildLoader({
       abspath: this.abspath,
       fsResolver: this.fsResolver,
-      redirects: this.redirects
-      excludes: excludes.filter(e => e.match(/.js$/)),
+      redirects: this.redirects,
+      excludes: excludes.filter(function(e) { return e.match(/.js$/); })
     });
     var analyzer = new hyd.Analyzer(true, loader);
     var analyzedExcludes = [];

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -414,11 +414,13 @@ Vulcan.prototype = {
   },
 
   getImplicitExcludes: function getImplicitExcludes(excludes) {
-    // Build a loader that doesn't have to stop at our excludes, since we need them.
+    // Build a loader that doesn't have to stop at our HTML excludes, since we
+    // need them. JS excludes should still be excluded.
     var loader = buildLoader({
       abspath: this.abspath,
       fsResolver: this.fsResolver,
       redirects: this.redirects
+      excludes: excludes.filter(e => e.match(/.js$/)),
     });
     var analyzer = new hyd.Analyzer(true, loader);
     var analyzedExcludes = [];

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -420,15 +420,15 @@ Vulcan.prototype = {
       abspath: this.abspath,
       fsResolver: this.fsResolver,
       redirects: this.redirects,
-      excludes: excludes.filter(function(e) { return e.match(/.js$/); })
+      excludes: excludes.filter(function(e) { return e.match(/.js$/i); })
     });
     var analyzer = new hyd.Analyzer(true, loader);
     var analyzedExcludes = [];
     excludes.forEach(function(exclude) {
-      if (exclude.match(/.js$/)) {
+      if (exclude.match(/.js$/i)) {
         return;
       }
-      if (exclude.match(/.css$/)) {
+      if (exclude.match(/.css$/i)) {
         return;
       }
       if (exclude.slice(-1) === '/') {


### PR DESCRIPTION
I believe this fixes https://github.com/Polymer/polymer-bundler/issues/440.