### PR TITLE
Honor the analyzer's resolved urls (present on the analyzer's documents, not import features)

### DIFF
--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -49,10 +49,10 @@ async function _getTransitiveDependencies(
 
         switch (htmlImport.type) {
           case 'html-import':
-            eagerImports.add(htmlImport.url);
+            eagerImports.add(htmlImport.document.url);
             break;
           case 'lazy-html-import':
-            lazyImports.add(htmlImport.url);
+            lazyImports.add(htmlImport.document.url);
             break;
         }
       }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -40,7 +40,8 @@ export async function inlineHtmlImport(
     docBundle: AssignedBundle,
     manifest: BundleManifest) {
   const rawImportUrl = dom5.getAttribute(linkTag, 'href')!;
-  const resolvedImportUrl = urlLib.resolve(document.url, rawImportUrl);
+  const importUrl = urlLib.resolve(document.url, rawImportUrl);
+  const resolvedImportUrl = document.analyzer.resolveUrl(importUrl);
   const importBundleUrl = manifest.bundleUrlForFile.get(resolvedImportUrl);
 
   // Don't reprocess the same file again.
@@ -89,7 +90,7 @@ export async function inlineHtmlImport(
   const htmlImport = findInSet(
       document.getByKind(
           'html-import', {imported: true, externalPackages: true}),
-      (i) => i.url === resolvedImportUrl);
+      (i) => i.document && i.document.url === resolvedImportUrl);
   if (!htmlImport) {
     return;
   }
@@ -119,11 +120,12 @@ export async function inlineHtmlImport(
  */
 export async function inlineScript(document: Document, scriptTag: ASTNode) {
   const rawImportUrl = dom5.getAttribute(scriptTag, 'src')!;
-  const resolvedImportUrl = urlLib.resolve(document.url, rawImportUrl);
+  const importUrl = urlLib.resolve(document.url, rawImportUrl);
+  const resolvedImportUrl = document.analyzer.resolveUrl(importUrl);
   const scriptImport = findInSet(
       document.getByKind(
           'html-script', {imported: true, externalPackages: true}),
-      (i) => i.url === resolvedImportUrl);
+      (i) => i.document.url === resolvedImportUrl);
   if (!scriptImport) {
     return;
   }
@@ -142,16 +144,17 @@ export async function inlineScript(document: Document, scriptTag: ASTNode) {
  */
 export async function inlineStylesheet(document: Document, cssLink: ASTNode) {
   const stylesheetUrl = dom5.getAttribute(cssLink, 'href')!;
-  const resolvedImportUrl = urlLib.resolve(document.url, stylesheetUrl);
+  const importUrl = urlLib.resolve(document.url, stylesheetUrl);
+  const resolvedImportUrl = document.analyzer.resolveUrl(importUrl);
   const stylesheetImport =  // HACK(usergenic): clang-format workaround
       findInSet(
           document.getByKind(
               'html-style', {imported: true, externalPackages: true}),
-          (i) => i.url === resolvedImportUrl) ||
+          (i) => i.document.url === resolvedImportUrl) ||
       findInSet(
           document.getByKind(
               'css-import', {imported: true, externalPackages: true}),
-          (i) => i.url === resolvedImportUrl);
+          (i) => i.document.url === resolvedImportUrl);
   if (!stylesheetImport) {
     return;
   }

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -125,7 +125,7 @@ export async function inlineScript(document: Document, scriptTag: ASTNode) {
   const scriptImport = findInSet(
       document.getByKind(
           'html-script', {imported: true, externalPackages: true}),
-      (i) => i.document.url === resolvedImportUrl);
+      (i) => i.document && i.document.url === resolvedImportUrl);
   if (!scriptImport) {
     return;
   }
@@ -150,11 +150,11 @@ export async function inlineStylesheet(document: Document, cssLink: ASTNode) {
       findInSet(
           document.getByKind(
               'html-style', {imported: true, externalPackages: true}),
-          (i) => i.document.url === resolvedImportUrl) ||
+          (i) => i.document && i.document.url === resolvedImportUrl) ||
       findInSet(
           document.getByKind(
               'css-import', {imported: true, externalPackages: true}),
-          (i) => i.document.url === resolvedImportUrl);
+          (i) => i.document && i.document.url === resolvedImportUrl);
   if (!stylesheetImport) {
     return;
   }

--- a/test/html/absolute-paths.html
+++ b/test/html/absolute-paths.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <link rel="import" href="/absolute-paths/import.html">
+    <title></title>
+  </head>
+  <body>
+  </body>
+</html>

--- a/test/html/absolute-paths/import.html
+++ b/test/html/absolute-paths/import.html
@@ -1,0 +1,2 @@
+<link rel="stylesheet" href="/absolute-paths/style.css">
+<script src="/absolute-paths/script.js"></script>

--- a/test/html/absolute-paths/script.js
+++ b/test/html/absolute-paths/script.js
@@ -1,0 +1,1 @@
+console.log('hello from /absolute-paths/script.js');

--- a/test/html/absolute-paths/style.css
+++ b/test/html/absolute-paths/style.css
@@ -1,0 +1,1 @@
+.absolute-paths-style { border: red; }


### PR DESCRIPTION
Fixes a bug where the Bundler can't properly deal with urls, especially absolute urls, even if the Analyzer has properly done so.  The problem stems from the Import feature urls not being resolved, so for now the bundler will honor the resolved url on the Import feature's documents.

The right thing to do down the line may be to update the Analyzer so that Import feature urls are resolved.

This PR has the tests anyways to keep from regressing if we switch back to Import feature urls.

Please note this PR merges into the `going-all-in-on-polymer-analyzer` branch #439 as opposed to `master`.