### PR TITLE
Excludes js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
-
+## 1.15.2 - 2016-12-16
 - Fix for how assetpath is set when in the same directory, where assetpath attribute
   for components in same directly were incorrectly set to "/".
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- `excludes` option now honors JavaScript asset references:
+  - Won't attempt to load the JS (which caused errors when local file not present.)
+  - Won't inline excluded JS files.
+
 ## 1.15.3 - 2017-01-17
 - Fix for how paths are rewritten in nested import scenarios where paths to same
   directory were ignored instead of treated as "." for relative path.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vulcanize",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Process Web Components into one output file",
   "main": "lib/vulcan.js",
   "bin": {

--- a/test/html/non-existent-script.html
+++ b/test/html/non-existent-script.html
@@ -1,0 +1,7 @@
+<html lang="en">
+<head>
+  <script src="non-existent.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -738,6 +738,47 @@ suite('Vulcan', function() {
       process(inputPath, callback, options);
     });
 
+    test('Excluded JavaScript is honored', function(done) {
+      var options = {
+        excludes: ["test/html/external/external.js"],
+        inlineScripts: true
+      };
+
+      var callback = function(err, doc) {
+        if (err) {
+          return done(err);
+        }
+        var script = dom5.query(doc, 
+          preds.AND(
+            preds.hasTagName('script'),
+            preds.hasAttrValue('src', 'external/external.js')));
+        assert.ok(script);
+        done();
+      }
+      process(path.resolve('test/html/external.html'), callback, options);
+    });
+
+    // Not Implemented
+    test.skip('Strip Excludes removes excluded JavaScript', function(done) {
+      var options = {
+        excludes: ["test/html/external/external.js"],
+        stripExcludes: true
+      };
+
+      var callback = function(err, doc) {
+        if (err) {
+          return done(err);
+        }
+        var script = dom5.query(doc, 
+          preds.AND(
+            preds.hasTagName('script'),
+            preds.hasAttrValue('src', 'external/external.js')));
+        assert.isNull(script);
+        done();
+      }
+      process(path.resolve('test/html/external.html'), callback, options);
+    });
+
     test('Strip Excludes does not have to be exact', function(done) {
       var options = {
         stripExcludes: ['simple-import']

--- a/test/test.js
+++ b/test/test.js
@@ -758,6 +758,20 @@ suite('Vulcan', function() {
       process(path.resolve('test/html/external.html'), callback, options);
     });
 
+    test('Excluded non-existent script will not attempt load', function(done) {
+      var options = {
+        excludes: ["test/html/non-existent.js"]
+      };
+
+      var callback = function(err) {
+        if (err) {
+          return done(err);
+        }
+        done();
+      }
+      process(path.resolve('test/html/non-existent-script.html'), callback, options);
+    });
+
     // Not Implemented
     test.skip('Strip Excludes removes excluded JavaScript', function(done) {
       var options = {


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Excludes now honors JavaScript asset references:
   - Won't attempt to load the JS (which caused errors when local file not present.)
   - Won't inline excluded JS files.