### PR TITLE
For bin/polymer-bundler, make FSUrlLoaderRoot the current working folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- The polymer-bundler CLI now uses the current working directory as
+  the package root folder for its Analyzer, allowing absolute paths to 
+  resolve properly.
 
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -19,7 +19,6 @@ import * as parse5 from 'parse5';
 import * as mkdirp from 'mkdirp';
 import * as pathLib from 'path';
 import {Bundler} from '../bundler';
-import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
 import {DocumentCollection} from '../document-collection';
 import {UrlString} from '../url-utils';
 import {BundleStrategy, generateShellMergeStrategy} from '../bundle-manifest';
@@ -184,8 +183,6 @@ options.stripComments = options['strip-comments'];
 options.implicitStrip = !options['no-implicit-strip'];
 options.inlineScripts = options['inline-scripts'];
 options.inlineCss = options['inline-css'];
-options.analyzer =
-    new Analyzer({urlLoader: new FSUrlLoader(pathLib.resolve('.'))});
 
 interface JsonManifest {
   [entrypoint: string]: UrlString[];

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -184,7 +184,8 @@ options.stripComments = options['strip-comments'];
 options.implicitStrip = !options['no-implicit-strip'];
 options.inlineScripts = options['inline-scripts'];
 options.inlineCss = options['inline-css'];
-options.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
+options.analyzer =
+    new Analyzer({urlLoader: new FSUrlLoader(pathLib.resolve('.'))});
 
 interface JsonManifest {
   [entrypoint: string]: UrlString[];

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+/// <reference path="../../node_modules/@types/chai/index.d.ts" />
+/// <reference path="../../node_modules/@types/node/index.d.ts" />
+/// <reference path="../../node_modules/@types/mocha/index.d.ts" />
+import * as chai from 'chai';
+import {execSync} from 'child_process';
+// import * as dom5 from 'dom5';
+// import * as parse5 from 'parse5';
+import * as path from 'path';
+// import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
+
+// import {Bundle} from '../bundle-manifest';
+// import {Bundler} from '../bundler';
+// import {Options as BundlerOptions} from '../bundler';
+
+chai.config.showDiff = true;
+
+const assert = chai.assert;
+// const matchers = require('../matchers');
+// const preds = dom5.predicates;
+
+suite('polymer-bundler CLI', () => {
+
+  test('uses the current working folder as loader root', async() => {
+    const projectRoot = path.resolve(__dirname, '../../test/html');
+    const cli = path.resolve(__dirname, '../bin/polymer-bundler.js');
+    const stdout =
+        execSync([
+          `cd ${projectRoot}`,
+          `node ${cli} absolute-paths.html --inline-scripts --inline-css`,
+        ].join(';'))
+            .toString();
+    assert.include(stdout, '.absolute-paths-style');
+    assert.include(stdout, 'hello from /absolute-paths/script.js');
+  });
+});

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -40,7 +40,7 @@ suite('polymer-bundler CLI', () => {
         execSync([
           `cd ${projectRoot}`,
           `node ${cli} absolute-paths.html --inline-scripts --inline-css`,
-        ].join(';'))
+        ].join(' && '))
             .toString();
     assert.include(stdout, '.absolute-paths-style');
     assert.include(stdout, 'hello from /absolute-paths/script.js');

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -16,20 +16,11 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 import * as chai from 'chai';
 import {execSync} from 'child_process';
-// import * as dom5 from 'dom5';
-// import * as parse5 from 'parse5';
 import * as path from 'path';
-// import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
-
-// import {Bundle} from '../bundle-manifest';
-// import {Bundler} from '../bundler';
-// import {Options as BundlerOptions} from '../bundler';
 
 chai.config.showDiff = true;
 
 const assert = chai.assert;
-// const matchers = require('../matchers');
-// const preds = dom5.predicates;
 
 suite('polymer-bundler CLI', () => {
 


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - The polymer-bundler CLI did not properly set up the root for the FSUrlLoader to be the working directory.
 - This meant absolute paths were essentially unsupported.
 - I've made cwd the FSUrlLoader root now.
 - I added an actual test for the bin file with execSync.