### PR TITLE
Add appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ example/bower_components
 **/.DS_Store
 typings
 lib
-.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "clang-format.style": "file",
+  "editor.formatOnSave": true,
+  "editor.formatOnType": true,
+  "search.exclude": {
+    "node_modules/": true,
+    "lib/": true
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+# Test against this version of Node.js
+environment:
+  nodejs_version: "4.8.0"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run test
+
+# Don't actually build.
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ test_script:
   - node --version
   - npm --version
   # run tests
-  - npm run test
+  - npm test
 
 # Don't actually build.
 build: off

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typings": "^1.3.2"
   },
   "scripts": {
-    "test": "npm run format && tsc && tslint -c tslint.json src/*.ts src/**/*.ts && mocha",
+    "test": "tsc && tslint -c tslint.json src/*.ts src/**/*.ts && mocha",
     "format": "find src | grep '\\.js$\\|\\.ts$' | xargs ./node_modules/.bin/clang-format --style=file -i"
   },
   "author": "The Polymer Project Authors",

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -38,7 +38,8 @@ suite('Bundler', () => {
         // Don't modify options directly because test-isolation problems occur.
         const bundlerOpts = Object.assign({}, opts || {});
         if (!bundlerOpts.analyzer) {
-          bundlerOpts.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
+          bundlerOpts.analyzer = new Analyzer(
+              {urlLoader: new FSUrlLoader(path.dirname(inputPath))});
           inputPath = path.basename(inputPath);
         }
         bundler = new Bundler(bundlerOpts);

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -20,8 +20,6 @@ import * as url from 'url';
 import {parseUrl} from 'polymer-analyzer/lib/utils';
 import constants from './constants';
 
-const pathPosix = path.posix;
-
 const sharedRelativeUrlProperties =
     ['protocol', 'slashes', 'auth', 'host', 'port', 'hostname'];
 
@@ -39,9 +37,9 @@ export function stripUrlFileSearchAndHash(href: UrlString): UrlString {
   // Using != so tests for null AND undefined
   if (u.pathname != null) {
     // Suffix path with `_` so that `/a/b/` is treated as `/a/b/_` and that
-    // `path.dirname()` returns `/a/b` because it would otherwise return `/a`
-    // incorrectly.
-    u.pathname = path.dirname(u.pathname + '_') + '/';
+    // `path.posix.dirname()` returns `/a/b` because it would otherwise
+    // return `/a` incorrectly.
+    u.pathname = path.posix.dirname(u.pathname + '_') + '/';
   }
   // Assigning to undefined because TSC says type of these is
   // `string | undefined` as opposed to `string | null`
@@ -84,7 +82,7 @@ export function relativeUrl(fromUri: UrlString, toUri: UrlString): UrlString {
   const toDir = toUrl.pathname !== undefined ? toUrl.pathname : '';
   // Note, below, the _ character is appended so that paths with trailing
   // slash retain the trailing slash in the path.relative result.
-  const relPath = path.relative(fromDir, toDir + '_').replace(/_$/, '');
+  const relPath = path.posix.relative(fromDir, toDir + '_').replace(/_$/, '');
   sharedRelativeUrlProperties.forEach((p) => toUrl[p] = null);
   toUrl.path = undefined;
   toUrl.pathname = relPath;
@@ -105,8 +103,8 @@ export function rewriteHrefBaseUrl(
   const parsedTo = url.parse(absUrl);
   if (parsedFrom.protocol === parsedTo.protocol &&
       parsedFrom.host === parsedTo.host) {
-    const pathname = pathPosix.relative(
-        pathPosix.dirname(parsedFrom.pathname || ''), parsedTo.pathname || '');
+    const pathname = path.posix.relative(
+        path.posix.dirname(parsedFrom.pathname || ''), parsedTo.pathname || '');
     return url.format(
         {pathname: pathname, search: parsedTo.search, hash: parsedTo.hash});
   }


### PR DESCRIPTION
 - Added an appveyor.yml
 - `npm test` didn't work on windows because it invoked a posix-specific `npm run format` script.
 - I removed `npm run format` from the `npm test` script, because vscode can enforce clang.
 - Added `.vscode` in (copied from polymer-build) and removed `.vscode` from the `.gitignore`.
 - Changed a couple of path related things to path.posix to fix broken tests on windows.