### PR TITLE
Changed the Bundler.bundle method to take a manifest from Bundler.generateManifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 <!-- ## Unreleased -->
 
+- BREAKING: Public API change.  The `bundle()` method now takes a manifest
+  instead of entrypoints, strategy and mapper.  To produce a manifest,
+  use new public method `generateManifest()`.
+
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
 
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,

--- a/README.md
+++ b/README.md
@@ -3,12 +3,20 @@
 
 # polymer-bundler
 
-### Reduce an HTML file and its dependent HTML Imports into one file
+polymer-bundler is a library for packaging project assets for production to minimize network round-trips.
 
 
-Web pages that use multiple [HTML Imports](http://www.html5rocks.com/en/tutorials/webcomponents/imports/) to load dependencies may end up making lots of network round-trips. In many cases, this can lead to long initial load times and unnecessary bandwidth usage. The polymer-bundler tool follows HTML Imports and `<script>` tags to inline these external assets into a single page, to be used in production.
+## Relationship to Polymer CLI
 
-In the future, technologies such as [HTTP/2](http://en.wikipedia.org/wiki/HTTP/2) and [Server Push](https://http2.github.io/faq/#whats-the-benefit-of-server-push) will likely obsolete the need for a tool like polymer-bundler for production uses.
+The [Polymer CLI](https://github.com/Polymer/polymer-cli) uses `polymer-bundle`
+
+
+## Usage
+
+Web pages that use multiple [HTML Imports](http://www.html5rocks.com/en/tutorials/webcomponents/imports/), external scripts, and stylesheets to load dependencies may end up making lots of network round-trips.  In many cases, this can lead to long initial load times and unnecessary bandwidth usage.  The polymer-bundler tool follows HTML Imports, external script and stylesheet references, inlining these external assets into "bundles", to be used in production.
+
+In the future, technologies such as [HTTP/2](http://en.wikipedia.org/wiki/HTTP/2) and [Server Push](https://http2.github.io/faq/#whats-the-benefit-of-server-push) will likely obsolete the need for a tool like polymer-bundler for web deployment uses.
+
 
 ## Installation
 
@@ -25,7 +33,7 @@ for this step).
 - `--exclude <path>`: exclude a subpath from root. Use multiple times to exclude multiple paths. Tags (imports/scripts/etc) that reference an excluded path are left in-place, meaning the resources are not inlined. ex: `--exclude=elements/x-foo.html --exclude=elements/x-bar.html`
 - `--inline-scripts`: Inline external scripts.
 - `--inline-css`: Inline external stylesheets.
-- `--redirect <uri>|<path>`: Takes an argument in the form of URI|PATH where url is a URI composed of a protocol, hostname, and path and PATH is a local filesystem path to replace the matched URI part with. Multiple redirects may be specified; the earliest ones have the highest priority.
+- `--shell`: Uses a bundling strategy which puts inlines shared dependencies into a specified html app "shell".
 - `--strip-comments`: Strips all HTML comments not containing an @license from the document.
 - `--sourcemaps`: Honor (or create) sourcemaps for inline script tags.
 - `--out-html <path>`: If specified, output will be written to <path> instead of stdout.
@@ -36,33 +44,25 @@ The command
 
     polymer-bundler target.html
 
-will inline the HTML Imports of `target.html` and print the resulting HTML to
-standard output.
+will inline the HTML Imports of `target.html` and print the resulting HTML to standard output.
 
 The command
 
     polymer-bundler target.html > build.html
 
-will inline the HTML Imports of `target.html` and print the result to
-`build.html`.
+will inline the HTML Imports of `target.html` and print the result to `build.html`.
 
 The command
 
     polymer-bundler -p "path/to/target/" /target.html
 
-will inline the HTML Imports of `target.html`, treat `path/to/target/` as the
-webroot of target.html, and make all urls absolute to the provided webroot.
+will inline the HTML Imports of `target.html`, treat `path/to/target/` as the webroot of target.html, and make all urls absolute to the provided webroot.
 
 The command
 
     polymer-bundler --exclude "path/to/target/subpath/" --exclude "path/to/target/subpath2/" target.html
 
-will inline the HTML Imports of `target.html` that are not in the directory
-`path/to/target/subpath` nor `path/to/target/subpath2`.
-
-If the `--strip-exclude` flag is used, the HTML Import `<link>` tags that
-point to resources in `path/to/target/subpath` and `path/to/target/subpath2/`
-will also be removed.
+will inline the HTML Imports of `target.html` that are not in the directory `path/to/target/subpath` nor `path/to/target/subpath2`.
 
 The command
 
@@ -80,66 +80,52 @@ The command
 
     polymer-bundler --strip-comments target.html
 
-will remove HTML comments, except for those that begin with `@license`.
-License comments will be deduplicated.
+will remove HTML comments, except for those that begin with `@license`.  License comments will be deduplicated.
 
 ## Using polymer-bundler programmatically
 
 polymer-bundler as a library has two exported function.
 
-`polymer-bundler` constructor takes an object of options similar to the command line
-options.
+`polymer-bundler` constructor takes an object of options similar to the
+command line options:
+
 - `excludes`: An array of strings with regular expressions to exclude paths from being inlined.
-- `stripExcludes`: Similar to `excludes`, but strips the imports from the output entirely.
-    - If `stripExcludes` is empty, it will be set the value of `excludes` by default.
-- `inlineScripts`: Inline external scripts.
 - `inlineCss`: Inline external stylesheets.
-- `addedImports`: Additional HTML imports to inline, added to the end of the
-    target file
-- `redirects`: An array of strings with the format `URI|PATH` where url is a URI composed of a protocol, hostname, and path and PATH is a local filesystem path to replace the matched URI part with. Multiple redirects may be specified; the earliest ones have the highest priority.
+- `inlineScripts`: Inline external scripts.
 - `sourcemaps`: Honor (or create) sourcemaps for inline scripts
 - `stripComments`: Remove non-license HTML comments.
-- `loader`: A [hydrolysis](https://www.npmjs.com/package/hydrolysis) loader.
-    This loader is generated with the `target` argument to `vulcan.process` and
-    the `exclude` paths. A custom loader can be given if more advanced setups
-    are necesssary.
 
-`polymer-bundler.process` takes a `target` path to `target.html` and a callback.
+`.generateManifest()` takes a collection of entrypoint urls and promises a `BundleManifest` which describes all the bundles it will produce.
+
+`.bundle()` takes a `BundleManifest` and returns a promise to a `DocumentCollection` of the generated bundles.
 
 Example:
 ```js
-var Bundler = require('polymer-bundler');
-var Analyzer = require('polymer-analyzer');
-
-
-var bundler = new Bundler({
-  excludes: [
-    '\\.css$'
-  ],
-  stripExcludes: [
-  ],
-  inlineScripts: false,
-  inlineCss: false,
-  addedImports: [
-  ],
-  redirects: [
-  ],
-  implicitStrip: true,
+var analyzer = new require('polymer-analyzer')({
+  urlLoader: new FSUrlLoader(path.resolve('.'))
+});
+var bundler = new require('polymer-bundler')({
+  analyzer: analyzer,
+  excludes: [],
+  inlineScripts: true,
+  inlineCss: true,
   stripComments: true
 });
-
-bundler.bundle([target]).then((bundles) => {
+bundler.generateManifest([target]).then((manifest) => {
+  bundler.bundle(manifest).then((bundles) => {
     /**
       * do stuff here
-      */
-})
+      */      
+  });
+});
 ```
 
 ## Caveats
 
-Because HTML Imports changes the order of execution scripts can have, polymer-bundler
-has to make a few compromises to achieve that same script execution order.
+Because HTML Imports changes the order of execution scripts can have, polymer-bundler has to make a few compromises to achieve that same script 
+execution order.
 
 1. Contents of all HTML Import documents will be moved to `<body>`
 
-1. Any scripts or styles, inline or linked, which occur after a `<link rel="import">` node in `<head>` will be moved to `<body>` after the contents of the HTML Import.
+1. Any scripts or styles, inline or linked, which occur after a `<link rel="import">` node in `<head>` will be moved to `<body>` after
+   the contents of the HTML Import.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ polymer-bundler is a library for packaging project assets for production to mini
 
 ## Relationship to Polymer CLI
 
-The [Polymer CLI](https://github.com/Polymer/polymer-cli) uses `polymer-bundle`
-
+The [Polymer CLI](https://github.com/Polymer/polymer-cli) uses [polymer-build](https://github.com/Polymer/polymer-build), which uses polymer-bundler, so you can think of the CLI's build pre-configured polymer-build pipeline including polymer-bundler. Setting this up for you makes the CLI easy to use, but as a command-line wrapper its customization options are more limited. polymer-bundler allows you to completely customize your bundle strategy.
 
 ## Usage
 
@@ -86,8 +85,7 @@ will remove HTML comments, except for those that begin with `@license`.  License
 
 polymer-bundler as a library has two exported function.
 
-`polymer-bundler` constructor takes an object of options similar to the
-command line options:
+`polymer-bundler` constructor takes an object of options similar to the command line options:
 
 - `excludes`: An array of strings with regular expressions to exclude paths from being inlined.
 - `inlineCss`: Inline external stylesheets.
@@ -127,5 +125,4 @@ execution order.
 
 1. Contents of all HTML Import documents will be moved to `<body>`
 
-1. Any scripts or styles, inline or linked, which occur after a `<link rel="import">` node in `<head>` will be moved to `<body>` after
-   the contents of the HTML Import.
+1. Any scripts or styles, inline or linked, which occur after a `<link rel="import">` node in `<head>` will be moved to `<body>` after the contents of the HTML Import.

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -213,7 +213,8 @@ function documentCollectionToManifestJson(documents: DocumentCollection):
       }
       strategy = generateShellMergeStrategy(shell, 2);
     }
-    bundles = await bundler.bundle(entrypoints, strategy);
+    const manifest = await bundler.generateManifest(entrypoints, strategy);
+    bundles = await bundler.bundle(manifest);
   } catch (err) {
     console.log(err);
     return;

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -65,7 +65,7 @@ export class BundleManifest {
   bundles: Map<UrlString, Bundle>;
 
   // Map of file url to bundle url.
-  bundleUrlForFile: Map<UrlString, UrlString>;
+  private _bundleUrlForFile: Map<UrlString, UrlString>;
 
   /**
    * Given a collection of bundles and a BundleUrlMapper to generate urls for
@@ -73,21 +73,21 @@ export class BundleManifest {
    */
   constructor(bundles: Bundle[], urlMapper: BundleUrlMapper) {
     this.bundles = urlMapper(Array.from(bundles));
-    this.bundleUrlForFile = new Map();
+    this._bundleUrlForFile = new Map();
 
     for (const bundleMapEntry of this.bundles) {
       const bundleUrl = bundleMapEntry[0];
       const bundle = bundleMapEntry[1];
       for (const fileUrl of bundle.files) {
-        console.assert(!this.bundleUrlForFile.has(fileUrl));
-        this.bundleUrlForFile.set(fileUrl, bundleUrl);
+        console.assert(!this._bundleUrlForFile.has(fileUrl));
+        this._bundleUrlForFile.set(fileUrl, bundleUrl);
       }
     }
   }
 
   // Convenience method to return a bundle for a constituent file url.
   getBundleForFile(url: UrlString): AssignedBundle|undefined {
-    const bundleUrl = this.bundleUrlForFile.get(url);
+    const bundleUrl = this._bundleUrlForFile.get(url);
     if (bundleUrl) {
       return {bundle: this.bundles.get(bundleUrl)!, url: bundleUrl};
     }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -102,8 +102,7 @@ export class Bundler {
    * documents with HTML imports, external stylesheets and external scripts
    * inlined according to the options for this Bundler.
    *
-   * @param {BundleManifest} manifest The manifest that describes the bundles
-   *     to be produced.
+   * @param manifest - The manifest that describes the bundles to be produced.
    */
   async bundle(manifest: BundleManifest): Promise<DocumentCollection> {
     const bundledDocuments: DocumentCollection =

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -98,19 +98,7 @@ export class Bundler {
   }
 
   /**
-   * Given urls to entrypoint html documents, produce a collection of bundled
-   * documents with HTML imports, external stylesheets and external scripts
-   * inlined according to the options for this Bundler.
-   *
-   * @param {Array<string>} entrypoints The list of entrypoints that will be
-   *     analyzed for dependencies. The results of the analysis will be passed
-   *     to the `strategy`.
-   * @param {BundleStrategy} strategy The strategy used to construct the
-   *     output bundles. See 'polymer-analyzer/src/bundle-manifest'.
-   * @param {BundleUrlMapper} mapper A function that produces urls for the
-   *     generated bundles. See 'polymer-analyzer/src/bundle-manifest'.
-
-   * Given urls to entrypoint html documents, produce a collection of bundled
+   * Given a manifest describing the bundles, produce a collection of bundled
    * documents with HTML imports, external stylesheets and external scripts
    * inlined according to the options for this Bundler.
    *
@@ -137,13 +125,13 @@ export class Bundler {
    * Generates a BundleManifest with all bundles defined, using entrypoints,
    * strategy and mapper.
    *
-   * @param {Array<string>} entrypoints The list of entrypoints that will be
-   *     analyzed for dependencies. The results of the analysis will be passed
-   *     to the `strategy`.
-   * @param {BundleStrategy} strategy The strategy used to construct the
-   *     output bundles. See 'polymer-analyzer/src/bundle-manifest'.
-   * @param {BundleUrlMapper} mapper A function that produces urls for the
-   *     generated bundles. See 'polymer-analyzer/src/bundle-manifest'.
+   * @param entrypoints - The list of entrypoints that will be analyzed for
+   *     dependencies. The results of the analysis will be passed to the
+   *     `strategy`.
+   * @param strategy - The strategy used to construct the output bundles.
+   *     See 'polymer-analyzer/src/bundle-manifest'.
+   * @param mapper - A function that produces urls for the generated bundles.
+   *     See 'polymer-analyzer/src/bundle-manifest'.
    */
   async generateManifest(
       entrypoints: UrlString[],

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -45,7 +45,7 @@ export async function inlineHtmlImport(
   const rawImportUrl = dom5.getAttribute(linkTag, 'href')!;
   const importUrl = urlLib.resolve(document.url, rawImportUrl);
   const resolvedImportUrl = document.analyzer.resolveUrl(importUrl);
-  const importBundleUrl = manifest.bundleUrlForFile.get(resolvedImportUrl);
+  const importBundle = manifest.getBundleForFile(resolvedImportUrl);
 
   // Don't reprocess the same file again.
   if (visitedUrls.has(resolvedImportUrl)) {
@@ -59,7 +59,7 @@ export async function inlineHtmlImport(
 
   // If we can't find a bundle for the referenced import, record that we've
   // processed it, but don't remove the import link.  Browser will handle it.
-  if (!importBundleUrl) {
+  if (!importBundle) {
     return;
   }
 
@@ -71,20 +71,20 @@ export async function inlineHtmlImport(
 
   // If the html import refers to a file which is bundled and has a different
   // url, then lets just rewrite the href to point to the bundle url.
-  if (importBundleUrl !== docBundle.url) {
+  if (importBundle.url !== docBundle.url) {
     // If we've previously visited a url that is part of another bundle, it
     // means we've handled that entire bundle, so we guard against inlining any
     // other file from that bundle by checking the visited urls for the bundle
     // url itself.
-    if (visitedUrls.has(importBundleUrl)) {
+    if (visitedUrls.has(importBundle.url)) {
       astUtils.removeElementAndNewline(linkTag);
       return;
     }
 
     const relative =
-        urlUtils.relativeUrl(document.url, importBundleUrl) || importBundleUrl;
+        urlUtils.relativeUrl(document.url, importBundle.url) || importBundle.url;
     dom5.setAttribute(linkTag, 'href', relative);
-    visitedUrls.add(importBundleUrl);
+    visitedUrls.add(importBundle.url);
     return;
   }
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -67,7 +67,7 @@ suite('BundleManifest', () => {
     });
 
     test('enables bundles to be found by constituent file', () => {
-      assert.equal(manifest.bundleUrlForFile.get('E'), 'A_B');
+      assert.equal(manifest.getBundleForFile('E')!.url, 'A_B');
       assert.equal(
           serializeBundle(manifest.getBundleForFile('E')!.bundle),
           '[A,B]->[E]');

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -44,7 +44,8 @@ suite('Bundler', () => {
           inputPath = path.basename(inputPath);
         }
         bundler = new Bundler(bundlerOpts);
-        const documents = await bundler.bundle([inputPath]);
+        const manifest = await bundler.generateManifest([inputPath]);
+        const documents = await bundler.bundle(manifest);
         return documents.get(inputPath)!.ast;
       }
 
@@ -79,8 +80,9 @@ suite('Bundler', () => {
         });
         return bundles;
       };
-      const documents =
-          await bundler.bundle(['test/html/default.html'], strategy);
+      const manifest =
+          await bundler.generateManifest(['test/html/default.html'], strategy);
+      const documents = await bundler.bundle(manifest);
       const document = documents.get('test/html/default.html')!;
       assert(document);
 
@@ -113,8 +115,9 @@ suite('Bundler', () => {
               new Set(['test/html/imports/simple-import.html']))
         ];
       };
-      const documents =
-          await bundler.bundle(['test/html/default.html'], strategy);
+      const manifest =
+          await bundler.generateManifest(['test/html/default.html'], strategy);
+      const documents = await bundler.bundle(manifest);
       const document = documents.get('test/html/default.html')!;
       assert(document);
 

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -49,7 +49,8 @@ suite('Bundler', () => {
           bundlerOpts.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
         }
         bundler = new Bundler(bundlerOpts);
-        return await bundler.bundle(inputPath, strategy);
+        const manifest = await bundler.generateManifest(inputPath, strategy);
+        return await bundler.bundle(manifest);
       }
 
   function assertContainsAndExcludes(

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -43,7 +43,8 @@ suite('Bundler', () => {
           inputPath = path.basename(inputPath);
         }
         bundler = new Bundler(bundlerOpts);
-        const documents = await bundler.bundle([inputPath]);
+        const manifest = await bundler.generateManifest([inputPath]);
+        const documents = await bundler.bundle(manifest);
         return documents.get(inputPath)!.ast;
       }
 


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - I updated README so it was at least more true than before.  It was woefully out-of-date.  Please don't review README for completeness as part of this branch, a broader README update is coming in subsequent PR.
 - This public API change is necessary to make it possible to identify the inlined content that should be filtered out of the build pipeline when bundling.
