### PR TITLE
Fix move style into template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,
   use new public method `generateManifest()`.
+- Fixed an issue where an immediate `<style>` child of `<dom-module>` was
+  not moved into generated `<template>`.
 
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -370,10 +370,11 @@ export class Bundler {
     let template = dom5.query(domModule, matchers.template);
     if (!template) {
       template = dom5.constructors.element('template')!;
-      dom5.append(domModule, template);
+      template['content'] = dom5.constructors.fragment();
+      astUtils.prepend(domModule, template);
     }
     astUtils.removeElementAndNewline(style);
-    astUtils.prepend(template, style);
+    astUtils.prepend(template['content'], style);
   }
 
   /**

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -13,7 +13,7 @@
  */
 import * as clone from 'clone';
 import * as dom5 from 'dom5';
-import {ASTNode, serialize} from 'parse5';
+import {ASTNode, serialize, treeAdapters} from 'parse5';
 import {Analyzer, Document, FSUrlLoader} from 'polymer-analyzer';
 
 import * as astUtils from './ast-utils';
@@ -370,11 +370,12 @@ export class Bundler {
     let template = dom5.query(domModule, matchers.template);
     if (!template) {
       template = dom5.constructors.element('template')!;
-      template['content'] = dom5.constructors.fragment();
+      treeAdapters.default.setTemplateContent(
+          template, dom5.constructors.fragment());
       astUtils.prepend(domModule, template);
     }
     astUtils.removeElementAndNewline(style);
-    astUtils.prepend(template['content'], style);
+    astUtils.prepend(treeAdapters.default.getTemplateContent(template), style);
   }
 
   /**

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -488,14 +488,14 @@ suite('Bundler', () => {
     test('All styles are inlined', async() => {
       const doc = await bundle(inputPath, options);
       const links = dom5.queryAll(doc, matchers.stylesheetImport);
-      const styles = dom5.queryAll(doc, matchers.styleMatcher);
+      const styles = dom5.queryAll(doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(links.length, 0);
       assert.equal(styles.length, 2);
     });
 
     test('Inlined styles have proper paths', async() => {
       const doc = await bundle('test/html/inline-styles.html', options);
-      const styles = dom5.queryAll(doc, matchers.styleMatcher);
+      const styles = dom5.queryAll(doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(styles.length, 2);
       const content = dom5.getTextContent(styles[1]);
       assert(content.search('imports/foo.jpg') > -1, 'path adjusted');
@@ -528,9 +528,9 @@ suite('Bundler', () => {
       assert(domModule);
       const template = dom5.query(domModule, matchers.template)!;
       assert(template);
-      const style =
-          dom5.queryAll(template.childNodes![0]!, matchers.styleMatcher);
-      assert.equal(style.length, 1);
+
+      const styles = dom5.queryAll(template, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
+      assert.equal(styles.length, 1);
     });
 
     test(
@@ -540,8 +540,7 @@ suite('Bundler', () => {
           assert(domModule);
           const template = dom5.query(domModule, matchers.template)!;
           assert(template);
-          const style =
-              dom5.query(template.childNodes![0]!, matchers.styleMatcher);
+        const style = dom5.query(template, matchers.styleMatcher, dom5.childNodesIncludeTemplate);
           assert(style);
         });
   });


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - The `_moveDomModuleStyleIntoTemplate` function did not get updated after `parse5` changed its handling of `<template>` content.  This updates bundler code to work with it correctly.
