### PR TITLE
Use new InMemoryOverlayUrlLoader from `polymer-analyzer` to support `analyze` method breaking change

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.2",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "2.0.0-alpha.35",
+    "polymer-analyzer": "2.0.0-alpha.36",
     "source-map": "^0.5.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.2",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "2.0.0-alpha.34",
+    "polymer-analyzer": "2.0.0-alpha.35",
     "source-map": "^0.5.6"
   },
   "devDependencies": {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -14,7 +14,8 @@
 import * as clone from 'clone';
 import * as dom5 from 'dom5';
 import {ASTNode, serialize, treeAdapters} from 'parse5';
-import {Analyzer, Document, FSUrlLoader} from 'polymer-analyzer';
+import * as path from 'path';
+import {Analyzer, Document, FSUrlLoader, InMemoryOverlayUrlLoader} from 'polymer-analyzer';
 
 import * as astUtils from './ast-utils';
 import * as bundleManifestLib from './bundle-manifest';
@@ -82,11 +83,29 @@ export class Bundler {
   stripComments: boolean;
   stripExcludes: UrlString[];
 
+  private _overlayUrlLoader: InMemoryOverlayUrlLoader;
+
   constructor(options?: Options) {
     const opts = options ? options : {};
-    this.analyzer = opts.analyzer ?
-        opts.analyzer :
-        new Analyzer({urlLoader: new FSUrlLoader()});
+
+    // In order for the bundler to use a given analyzer, we'll have to fork it
+    // so we can provide our own overlayUrlLoader which falls back to the
+    // analyzer's load method.
+    //
+    // TODO(usergenic): We can't delegate to `canLoad` directly, so we're
+    // proxying via the analyzer's `canResolveUrl` method.  We need to either
+    // expose `urlLoader` publicly on the analyzer or add a `canLoad` method.
+    if (opts.analyzer) {
+      this._overlayUrlLoader = new InMemoryOverlayUrlLoader({
+        canLoad: (url: string) => opts.analyzer!.canResolveUrl(url),
+        load: async(url: string) => opts.analyzer!.load(url),
+      });
+      this.analyzer = opts.analyzer._fork({urlLoader: this._overlayUrlLoader});
+    } else {
+      this._overlayUrlLoader =
+          new InMemoryOverlayUrlLoader(new FSUrlLoader(path.resolve('.')));
+      this.analyzer = new Analyzer({urlLoader: this._overlayUrlLoader});
+    }
 
     // implicitStrip should be true by default
     this.implicitStrip = !Boolean(opts.noImplicitStrip);
@@ -149,6 +168,17 @@ export class Bundler {
     this._filterExcludesFromBundles(bundles);
     bundles = strategy(bundles);
     return new BundleManifest(bundles, mapper);
+  }
+
+  /**
+   * Analyze a url using the given contents in place of what would otherwise
+   * have been loaded.
+   */
+  private async _analyzeContents(url: string, contents: string):
+      Promise<Document> {
+    this._overlayUrlLoader.urlContentsMap.set(url, contents);
+    this.analyzer.filesChanged([url]);
+    return this.analyzer.analyze(url);
   }
 
   /**
@@ -219,7 +249,7 @@ export class Bundler {
     // Re-analyzing the document using the updated ast to refresh the scanned
     // imports, since we may now have appended some that were not initially
     // present.
-    document = await this.analyzer.analyze(document.url, serialize(ast));
+    document = await this._analyzeContents(document.url, serialize(ast));
 
     // The following set of operations manipulate the ast directly, so
     await this._inlineHtmlImports(document, ast, docBundle, bundleManifest);
@@ -426,12 +456,12 @@ export class Bundler {
   private async _prepareBundleDocument(bundle: AssignedBundle):
       Promise<Document> {
     if (!bundle.bundle.files.has(bundle.url)) {
-      return await this.analyzer.analyze(bundle.url, '');
+      return this._analyzeContents(bundle.url, '');
     }
     const document = await this.analyzer.analyze(bundle.url);
     const ast = clone(document.parsedDocument.ast);
     this._moveOrderedImperativesFromHeadIntoHiddenDiv(ast);
     this._moveUnhiddenHtmlImportsIntoHiddenDiv(ast);
-    return await this.analyzer.analyze(document.url, serialize(ast));
+    return this._analyzeContents(document.url, serialize(ast));
   }
 }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -95,6 +95,7 @@ export class Bundler {
     // TODO(usergenic): We can't delegate to `canLoad` directly, so we're
     // proxying via the analyzer's `canResolveUrl` method.  We need to either
     // expose `urlLoader` publicly on the analyzer or add a `canLoad` method.
+    // https://github.com/Polymer/polymer-analyzer/issues/612
     if (opts.analyzer) {
       this._overlayUrlLoader = new InMemoryOverlayUrlLoader({
         canLoad: (url: string) => opts.analyzer!.canResolveUrl(url),

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -97,11 +97,12 @@ export class Bundler {
     // expose `urlLoader` publicly on the analyzer or add a `canLoad` method.
     // https://github.com/Polymer/polymer-analyzer/issues/612
     if (opts.analyzer) {
+      const analyzer = opts.analyzer;
       this._overlayUrlLoader = new InMemoryOverlayUrlLoader({
-        canLoad: (url: string) => opts.analyzer!.canResolveUrl(url),
-        load: async(url: string) => opts.analyzer!.load(url),
+        canLoad: (url: string) => analyzer.canResolveUrl(url),
+        load: async(url: string) => analyzer.load(url),
       });
-      this.analyzer = opts.analyzer._fork({urlLoader: this._overlayUrlLoader});
+      this.analyzer = analyzer._fork({urlLoader: this._overlayUrlLoader});
     } else {
       this._overlayUrlLoader =
           new InMemoryOverlayUrlLoader(new FSUrlLoader(path.resolve('.')));

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -488,14 +488,16 @@ suite('Bundler', () => {
     test('All styles are inlined', async() => {
       const doc = await bundle(inputPath, options);
       const links = dom5.queryAll(doc, matchers.stylesheetImport);
-      const styles = dom5.queryAll(doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
+      const styles = dom5.queryAll(
+          doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(links.length, 0);
       assert.equal(styles.length, 2);
     });
 
     test('Inlined styles have proper paths', async() => {
       const doc = await bundle('test/html/inline-styles.html', options);
-      const styles = dom5.queryAll(doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
+      const styles = dom5.queryAll(
+          doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(styles.length, 2);
       const content = dom5.getTextContent(styles[1]);
       assert(content.search('imports/foo.jpg') > -1, 'path adjusted');
@@ -529,7 +531,8 @@ suite('Bundler', () => {
       const template = dom5.query(domModule, matchers.template)!;
       assert(template);
 
-      const styles = dom5.queryAll(template, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
+      const styles = dom5.queryAll(
+          template, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(styles.length, 1);
     });
 
@@ -540,7 +543,8 @@ suite('Bundler', () => {
           assert(domModule);
           const template = dom5.query(domModule, matchers.template)!;
           assert(template);
-        const style = dom5.query(template, matchers.styleMatcher, dom5.childNodesIncludeTemplate);
+          const style = dom5.query(
+              template, matchers.styleMatcher, dom5.childNodesIncludeTemplate);
           assert(style);
         });
   });


### PR DESCRIPTION
Analyzer dropped support for `analyze(url, contents)` but added an `InMemoryOverlayUrlLoader` as a convention to provide a map of urls to string contents.  This PR attempts to work with this new API while preserving the bundler's logic.

The approach is to create a private method on the `Bundler` itself to emulate the old `analyze` method signature and setup the overlay in the constructor.