### PR TITLE
Use the new version of the Analyzer which implements UrlLoader.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.2",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "2.0.0-alpha.36",
+    "polymer-analyzer": "2.0.0-alpha.37",
     "source-map": "^0.5.6"
   },
   "devDependencies": {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -91,17 +91,9 @@ export class Bundler {
     // In order for the bundler to use a given analyzer, we'll have to fork it
     // so we can provide our own overlayUrlLoader which falls back to the
     // analyzer's load method.
-    //
-    // TODO(usergenic): We can't delegate to `canLoad` directly, so we're
-    // proxying via the analyzer's `canResolveUrl` method.  We need to either
-    // expose `urlLoader` publicly on the analyzer or add a `canLoad` method.
-    // https://github.com/Polymer/polymer-analyzer/issues/612
     if (opts.analyzer) {
       const analyzer = opts.analyzer;
-      this._overlayUrlLoader = new InMemoryOverlayUrlLoader({
-        canLoad: (url: string) => analyzer.canResolveUrl(url),
-        load: async(url: string) => analyzer.load(url),
-      });
+      this._overlayUrlLoader = new InMemoryOverlayUrlLoader(analyzer);
       this.analyzer = analyzer._fork({urlLoader: this._overlayUrlLoader});
     } else {
       this._overlayUrlLoader =


### PR DESCRIPTION
Once Analyzer 2.0.0-alpha.37 is released, this code simplifies the constructor and fixes a bug where we incorrectly rely on `canResolveUrl` to proxy for `canLoad`.