### PR TITLE
Don't rewrite template url attributes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   instead of entrypoints, strategy and mapper.  To produce a manifest,
   use new public method `generateManifest()`.
 - The polymer-bundler CLI now uses the current working directory as
-  the package root folder for its Analyzer, allowing absolute paths to 
+  the package root folder for its Analyzer, allowing absolute paths to
   resolve properly.
 - Fixed an issue where an immediate `<style>` child of `<dom-module>` was
   not moved into generated `<template>`.
-- BREAKING: Added option `rewriteTemplateUrls` to support old-style rewriting
-  of urls in element attributes for elements inside templates in inlined html
-  imports.  No longer does this by default.
+- BREAKING: Added option `rewriteUrlsInTemplates` to support rewriting of urls
+  found in `style` tags and in `src`, `href`, `action`, and `style` attributes
+  found inside `<template>` elements, when inlining html imports.  Previously,
+  this was done by default.  Now requires explicit option.
 
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed an issue where an immediate `<style>` child of `<dom-module>` was
   not moved into generated `<template>`.
 - BREAKING: Added option `rewriteUrlsInTemplates` to support rewriting of urls
-  found in `style` tags and in `src`, `href`, `action`, and `style` attributes
+  found in `src`, `href`, `action`, `assetpath` and `style` attributes
   found inside `<template>` elements, when inlining html imports.  Previously,
   this was done by default.  Now requires explicit option.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   use new public method `generateManifest()`.
 - Fixed an issue where an immediate `<style>` child of `<dom-module>` was
   not moved into generated `<template>`.
+- BREAKING: Added option `rewriteTemplateUrls` to support old-style rewriting
+  of urls in element attributes for elements inside templates in inlined html
+  imports.  No longer does this by default.
 
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -59,7 +59,7 @@ export interface Options {
 
   // Rewrite element attributes inside of templates to adjust urls in inlined
   // html imports.
-  rewriteTemplateUrlAttrs?: boolean;
+  rewriteUrlsInTemplates?: boolean;
 
   // Create identity source maps for inline scripts
   sourcemaps?: boolean;
@@ -83,7 +83,7 @@ export class Bundler {
   enableScriptInlining: boolean;
   excludes: UrlString[];
   implicitStrip: boolean;
-  rewriteTemplateUrlAttrs: boolean;
+  rewriteUrlsInTemplates: boolean;
   sourcemaps: boolean;
   stripComments: boolean;
   stripExcludes: UrlString[];
@@ -120,7 +120,7 @@ export class Bundler {
     this.stripComments = Boolean(opts.stripComments);
     this.enableCssInlining = Boolean(opts.inlineCss);
     this.enableScriptInlining = Boolean(opts.inlineScripts);
-    this.rewriteTemplateUrlAttrs = Boolean(opts.rewriteTemplateUrlAttrs);
+    this.rewriteUrlsInTemplates = Boolean(opts.rewriteUrlsInTemplates);
     this.sourcemaps = Boolean(opts.sourcemaps);
   }
 
@@ -253,7 +253,7 @@ export class Bundler {
     const ast = clone(document.parsedDocument.ast);
     this._appendHtmlImportsForBundle(ast, docBundle);
     importUtils.rewriteAstToEmulateBaseTag(
-        ast, document.url, this.rewriteTemplateUrlAttrs);
+        ast, document.url, this.rewriteUrlsInTemplates);
 
     // Re-analyzing the document using the updated ast to refresh the scanned
     // imports, since we may now have appended some that were not initially
@@ -349,7 +349,7 @@ export class Bundler {
           bundle,
           bundleManifest,
           this.sourcemaps,
-          this.rewriteTemplateUrlAttrs);
+          this.rewriteUrlsInTemplates);
     }
   }
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -57,6 +57,10 @@ export interface Options {
   // the output document.
   inlineScripts?: boolean;
 
+  // Rewrite element attributes inside of templates to adjust urls in inlined
+  // html imports.
+  rewriteTemplateUrlAttrs?: boolean;
+
   // Create identity source maps for inline scripts
   sourcemaps?: boolean;
 
@@ -79,6 +83,7 @@ export class Bundler {
   enableScriptInlining: boolean;
   excludes: UrlString[];
   implicitStrip: boolean;
+  rewriteTemplateUrlAttrs: boolean;
   sourcemaps: boolean;
   stripComments: boolean;
   stripExcludes: UrlString[];
@@ -115,6 +120,7 @@ export class Bundler {
     this.stripComments = Boolean(opts.stripComments);
     this.enableCssInlining = Boolean(opts.inlineCss);
     this.enableScriptInlining = Boolean(opts.inlineScripts);
+    this.rewriteTemplateUrlAttrs = Boolean(opts.rewriteTemplateUrlAttrs);
     this.sourcemaps = Boolean(opts.sourcemaps);
   }
 
@@ -246,7 +252,8 @@ export class Bundler {
 
     const ast = clone(document.parsedDocument.ast);
     this._appendHtmlImportsForBundle(ast, docBundle);
-    importUtils.rewriteAstToEmulateBaseTag(ast, document.url);
+    importUtils.rewriteAstToEmulateBaseTag(
+        ast, document.url, this.rewriteTemplateUrlAttrs);
 
     // Re-analyzing the document using the updated ast to refresh the scanned
     // imports, since we may now have appended some that were not initially
@@ -341,7 +348,8 @@ export class Bundler {
           visitedUrls,
           bundle,
           bundleManifest,
-          this.sourcemaps);
+          this.sourcemaps,
+          this.rewriteTemplateUrlAttrs);
     }
   }
 

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -41,7 +41,8 @@ export async function inlineHtmlImport(
     visitedUrls: Set<UrlString>,
     docBundle: AssignedBundle,
     manifest: BundleManifest,
-    enableSourcemaps: boolean) {
+    enableSourcemaps: boolean,
+    rewriteTemplateUrlAttrs: boolean) {
   const rawImportUrl = dom5.getAttribute(linkTag, 'href')!;
   const importUrl = urlLib.resolve(document.url, rawImportUrl);
   const resolvedImportUrl = document.analyzer.resolveUrl(importUrl);
@@ -81,8 +82,8 @@ export async function inlineHtmlImport(
       return;
     }
 
-    const relative =
-        urlUtils.relativeUrl(document.url, importBundle.url) || importBundle.url;
+    const relative = urlUtils.relativeUrl(document.url, importBundle.url) ||
+        importBundle.url;
     dom5.setAttribute(linkTag, 'href', relative);
     visitedUrls.add(importBundle.url);
     return;
@@ -102,8 +103,10 @@ export async function inlineHtmlImport(
   // not get html, head or body wrappers.
   const importAst = parse5.parseFragment(
       htmlImport.document.parsedDocument.contents, {locationInfo: true});
-  rewriteAstToEmulateBaseTag(importAst, resolvedImportUrl);
-  rewriteAstBaseUrl(importAst, resolvedImportUrl, document.url);
+  rewriteAstToEmulateBaseTag(
+      importAst, resolvedImportUrl, rewriteTemplateUrlAttrs);
+  rewriteAstBaseUrl(
+      importAst, resolvedImportUrl, document.url, rewriteTemplateUrlAttrs);
 
   if (enableSourcemaps) {
     const reparsedDoc = new ParsedHtmlDocument({
@@ -131,7 +134,8 @@ export async function inlineHtmlImport(
         visitedUrls,
         docBundle,
         manifest,
-        enableSourcemaps);
+        enableSourcemaps,
+        rewriteTemplateUrlAttrs);
   }
 }
 
@@ -212,7 +216,8 @@ export async function inlineStylesheet(document: Document, cssLink: ASTNode) {
  * Given an import document with a base tag, transform all of its URLs and set
  * link and form target attributes and remove the base tag.
  */
-export function rewriteAstToEmulateBaseTag(ast: ASTNode, docUrl: UrlString) {
+export function rewriteAstToEmulateBaseTag(
+    ast: ASTNode, docUrl: UrlString, rewriteTemplateUrlAttrs: boolean) {
   const baseTag = dom5.query(ast, matchers.base);
   const p = dom5.predicates;
   // If there's no base tag, there's nothing to do.
@@ -224,7 +229,7 @@ export function rewriteAstToEmulateBaseTag(ast: ASTNode, docUrl: UrlString) {
   }
   if (dom5.predicates.hasAttr('href')(baseTag)) {
     const baseUrl = urlLib.resolve(docUrl, dom5.getAttribute(baseTag, 'href')!);
-    rewriteAstBaseUrl(ast, baseUrl, docUrl);
+    rewriteAstBaseUrl(ast, baseUrl, docUrl, rewriteTemplateUrlAttrs);
   }
   if (p.hasAttr('target')(baseTag)) {
     const baseTarget = dom5.getAttribute(baseTag, 'target')!;
@@ -245,9 +250,13 @@ export function rewriteAstToEmulateBaseTag(ast: ASTNode, docUrl: UrlString) {
  * imported from the import url.
  */
 export function rewriteAstBaseUrl(
-    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
-  rewriteElementAttrsBaseUrl(ast, oldBaseUrl, newBaseUrl);
-  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl);
+    ast: ASTNode,
+    oldBaseUrl: UrlString,
+    newBaseUrl: UrlString,
+    rewriteTemplateUrlAttrs: boolean) {
+  rewriteElementAttrsBaseUrl(
+      ast, oldBaseUrl, newBaseUrl, rewriteTemplateUrlAttrs);
+  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl, rewriteTemplateUrlAttrs);
   setDomModuleAssetpaths(ast, oldBaseUrl, newBaseUrl);
 }
 
@@ -318,9 +327,16 @@ function rewriteCssTextBaseUrl(
  * are based on the relationship of the old base url to the new base url.
  */
 function rewriteElementAttrsBaseUrl(
-    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
+    ast: ASTNode,
+    oldBaseUrl: UrlString,
+    newBaseUrl: UrlString,
+    rewriteTemplateUrlAttrs: boolean) {
   const nodes = dom5.queryAll(
-      ast, matchers.urlAttrs, undefined, dom5.childNodesIncludeTemplate);
+      ast,
+      matchers.urlAttrs,
+      undefined,
+      rewriteTemplateUrlAttrs ? dom5.childNodesIncludeTemplate :
+                                dom5.defaultChildNodes);
   for (const node of nodes) {
     for (const attr of constants.URL_ATTR) {
       const attrValue = dom5.getAttribute(node, attr);
@@ -343,9 +359,16 @@ function rewriteElementAttrsBaseUrl(
  * on the relationship of the old base url to the new base url.
  */
 function rewriteStyleTagsBaseUrl(
-    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
+    ast: ASTNode,
+    oldBaseUrl: UrlString,
+    newBaseUrl: UrlString,
+    rewriteTemplateUrlAttrs: boolean) {
   const styleNodes = dom5.queryAll(
-      ast, matchers.styleMatcher, undefined, dom5.childNodesIncludeTemplate);
+      ast,
+      matchers.styleMatcher,
+      undefined,
+      rewriteTemplateUrlAttrs ? dom5.childNodesIncludeTemplate :
+                                dom5.defaultChildNodes);
   for (const node of styleNodes) {
     let styleText = dom5.getTextContent(node);
     styleText = rewriteCssTextBaseUrl(styleText, oldBaseUrl, newBaseUrl);

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -42,7 +42,7 @@ export async function inlineHtmlImport(
     docBundle: AssignedBundle,
     manifest: BundleManifest,
     enableSourcemaps: boolean,
-    rewriteTemplateUrlAttrs: boolean) {
+    rewriteTemplateUrlAttrs?: boolean) {
   const rawImportUrl = dom5.getAttribute(linkTag, 'href')!;
   const importUrl = urlLib.resolve(document.url, rawImportUrl);
   const resolvedImportUrl = document.analyzer.resolveUrl(importUrl);
@@ -217,7 +217,7 @@ export async function inlineStylesheet(document: Document, cssLink: ASTNode) {
  * link and form target attributes and remove the base tag.
  */
 export function rewriteAstToEmulateBaseTag(
-    ast: ASTNode, docUrl: UrlString, rewriteTemplateUrlAttrs: boolean) {
+    ast: ASTNode, docUrl: UrlString, rewriteTemplateUrlAttrs?: boolean) {
   const baseTag = dom5.query(ast, matchers.base);
   const p = dom5.predicates;
   // If there's no base tag, there's nothing to do.
@@ -253,7 +253,7 @@ export function rewriteAstBaseUrl(
     ast: ASTNode,
     oldBaseUrl: UrlString,
     newBaseUrl: UrlString,
-    rewriteTemplateUrlAttrs: boolean) {
+    rewriteTemplateUrlAttrs?: boolean) {
   rewriteElementAttrsBaseUrl(
       ast, oldBaseUrl, newBaseUrl, rewriteTemplateUrlAttrs);
   rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl, rewriteTemplateUrlAttrs);
@@ -330,7 +330,7 @@ function rewriteElementAttrsBaseUrl(
     ast: ASTNode,
     oldBaseUrl: UrlString,
     newBaseUrl: UrlString,
-    rewriteTemplateUrlAttrs: boolean) {
+    rewriteTemplateUrlAttrs?: boolean) {
   const nodes = dom5.queryAll(
       ast,
       matchers.urlAttrs,
@@ -362,7 +362,7 @@ function rewriteStyleTagsBaseUrl(
     ast: ASTNode,
     oldBaseUrl: UrlString,
     newBaseUrl: UrlString,
-    rewriteTemplateUrlAttrs: boolean) {
+    rewriteTemplateUrlAttrs?: boolean) {
   const styleNodes = dom5.queryAll(
       ast,
       matchers.styleMatcher,

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -256,7 +256,7 @@ export function rewriteAstBaseUrl(
     rewriteUrlsInTemplates?: boolean) {
   rewriteElementAttrsBaseUrl(
       ast, oldBaseUrl, newBaseUrl, rewriteUrlsInTemplates);
-  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl, rewriteUrlsInTemplates);
+  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl);
   setDomModuleAssetpaths(ast, oldBaseUrl, newBaseUrl);
 }
 
@@ -359,16 +359,9 @@ function rewriteElementAttrsBaseUrl(
  * on the relationship of the old base url to the new base url.
  */
 function rewriteStyleTagsBaseUrl(
-    ast: ASTNode,
-    oldBaseUrl: UrlString,
-    newBaseUrl: UrlString,
-    rewriteUrlsInTemplates?: boolean) {
+    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
   const styleNodes = dom5.queryAll(
-      ast,
-      matchers.styleMatcher,
-      undefined,
-      rewriteUrlsInTemplates ? dom5.childNodesIncludeTemplate :
-                               dom5.defaultChildNodes);
+      ast, matchers.styleMatcher, undefined, dom5.childNodesIncludeTemplate);
   for (const node of styleNodes) {
     let styleText = dom5.getTextContent(node);
     styleText = rewriteCssTextBaseUrl(styleText, oldBaseUrl, newBaseUrl);

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -85,7 +85,7 @@ suite('import-utils', () => {
           </head><body><dom-module id="my-element" assetpath="my-element/">
           <template>
           <img src="neato.gif">
-          <style>:host { background-image: url(background.svg); }</style>
+          <style>:host { background-image: url("my-element/background.svg"); }</style>
           <div style="position: absolute;"></div>
           </template>
           </dom-module>

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -60,7 +60,7 @@ suite('import-utils', () => {
       const rewriteCssTextBaseUrl =
           importUtils.__get__('rewriteCssTextBaseUrl');
       const actual = rewriteCssTextBaseUrl(css, importDocPath, mainDocPath);
-      assert.equal(actual, expected);
+      assert.deepEqual(actual, expected);
     });
 
     test('Resolve Paths', () => {
@@ -89,10 +89,10 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(html);
-      importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath);
+      importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath, true);
 
       const actual = parse5.serialize(ast);
-      assert.equal(stripSpace(actual), stripSpace(expected), 'relative');
+      assert.deepEqual(stripSpace(actual), stripSpace(expected), 'relative');
     });
 
     test('Leave Templated URLs', () => {
@@ -104,7 +104,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(base);
-      importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath);
+      importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath, true);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(base), 'templated urls');
@@ -142,7 +142,7 @@ suite('import-utils', () => {
         </body></html>`;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url');
+      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url', true);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(expectedBase), 'base');
@@ -178,7 +178,7 @@ suite('import-utils', () => {
       `;
 
       const ast = parse5.parse(htmlBase);
-      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url');
+      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url', true);
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(expectedBase), 'base');

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -99,7 +99,7 @@ suite('import-utils', () => {
         assert.deepEqual(stripSpace(actual), stripSpace(expected), 'relative');
       });
 
-      test('including template elements (rewriteTemplateUrlAttrs=true)', () => {
+      test('including template elements (rewriteUrlsInTemplates=true)', () => {
         const html = `
           <link rel="import" href="../polymer/polymer.html">
           <link rel="stylesheet" href="my-element.css">


### PR DESCRIPTION
Polymer 2.0 + HTML Imports polyfill etc doesn't rewrite urls inside `<template>` tags.  So Bundler won't unless a new `rewriteTemplateUrlAttrs` option is provided as `true`.

 - [x] CHANGELOG.md has been updated
 - Fixes https://github.com/Polymer/polymer-bundler/issues/441