### PR TITLE
Trim trailing whitespace on file save in vscode.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
   "editor.detectIndentation": false,
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
+  "files.trimTrailingWhitespace": true,
   "editor.tabSize": 2,
   "files.insertFinalNewline": true,
   "search.exclude": {


### PR DESCRIPTION
This adds `"files.trimTrailingWhitespace": true` to `.vscode/settings.json`

