### PR TITLE
Don't add html, head or body tags to bundled documents.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   found in `src`, `href`, `action`, `assetpath` and `style` attributes
   found inside `<template>` elements, when inlining html imports.  Previously,
   this was done by default.  Now requires explicit option.
+- Fixed an issue where bundler was adding `<html>`, `<head>`, and `<body>` tags
+  to documents that didn't have them.
 
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -115,6 +115,7 @@ const injectedTagNames = new Set(['html', 'head', 'body']);
  *
  * TODO(usergenic): Remove this function after porting it to dom5.  Also
  * remove from `polymer-analyzer` since that's where this was duplicated from.
+ * https://github.com/Polymer/dom5/issues/49
  */
 export function removeFakeNodes(ast: dom5.Node) {
   const children = (ast.childNodes || []).slice();

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -112,6 +112,9 @@ const injectedTagNames = new Set(['html', 'head', 'body']);
  * node has no `__location` information, so this function can only reliably
  * be used on a fresh parse, since subsequent tree manipulations may inject
  * nodes without location information.
+ *
+ * TODO(usergenic): Remove this function after porting it to dom5.  Also
+ * remove from `polymer-analyzer` since that's where this was duplicated from.
  */
 export function removeFakeNodes(ast: dom5.Node) {
   const children = (ast.childNodes || []).slice();

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -251,6 +251,7 @@ export class Bundler {
     let document = await this._prepareBundleDocument(docBundle);
 
     const ast = clone(document.parsedDocument.ast);
+    astUtils.removeFakeNodes(ast);
     this._appendHtmlImportsForBundle(ast, docBundle);
     importUtils.rewriteAstToEmulateBaseTag(
         ast, document.url, this.rewriteUrlsInTemplates);
@@ -472,6 +473,7 @@ export class Bundler {
     const ast = clone(document.parsedDocument.ast);
     this._moveOrderedImperativesFromHeadIntoHiddenDiv(ast);
     this._moveUnhiddenHtmlImportsIntoHiddenDiv(ast);
+    astUtils.removeFakeNodes(ast);
     return this._analyzeContents(document.url, serialize(ast));
   }
 }

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -19,7 +19,7 @@ import {Analyzer, Document, ParsedHtmlDocument} from 'polymer-analyzer';
 import {AnalysisContext} from 'polymer-analyzer/lib/core/analysis-context';
 import {RawSourceMap, SourceMapConsumer, SourceMapGenerator} from 'source-map';
 import * as urlLib from 'url';
-
+import * as astUtils from './ast-utils';
 import * as matchers from './matchers';
 
 const inlineSourcemapPrefix =
@@ -197,7 +197,7 @@ export function updateSourcemapLocations(
     document: Document, ast: parse5.ASTNode) {
   // We need to serialize and reparse the dom for updated location information
   const documentContents = parse5.serialize(ast);
-  ast = parse5.parse(documentContents, {locationInfo: true});
+  ast = astUtils.parse(documentContents, {locationInfo: true});
 
   const reparsedDoc = new ParsedHtmlDocument({
     url: document.url,

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -130,6 +130,21 @@ suite('Bundler', () => {
       assert(linkTag);
       assert.equal(
           dom5.getAttribute(linkTag, 'href'), '../../shared_bundle_1.html');
+
+      const shared = documents.get('shared_bundle_1.html')!;
+      assert(shared);
+      assert.isOk(dom5.query(
+          shared.ast, dom5.predicates.hasAttrValue('id', 'my-element')));
+    });
+
+    test('bundle documents should not have tags added to them', async() => {
+      const ast = await bundle('test/html/imports/simple-import.html');
+      assert.isNull(dom5.query(
+          ast,
+          dom5.predicates.OR(
+              dom5.predicates.hasTagName('html'),
+              dom5.predicates.hasTagName('head'),
+              dom5.predicates.hasTagName('body'))));
     });
   });
 

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -18,6 +18,7 @@ import * as chai from 'chai';
 import * as parse5 from 'parse5';
 
 const rewire = require('rewire');
+const astUtils = require('../ast-utils');
 const importUtils = rewire('../import-utils');
 
 chai.config.showDiff = true;
@@ -80,19 +81,19 @@ suite('import-utils', () => {
         `;
 
         const expected = `
-          <html><head><link rel="import" href="polymer/polymer.html">
+          <link rel="import" href="polymer/polymer.html">
           <link rel="stylesheet" href="my-element/my-element.css">
-          </head><body><dom-module id="my-element" assetpath="my-element/">
+          <dom-module id="my-element" assetpath="my-element/">
           <template>
           <img src="neato.gif">
           <style>:host { background-image: url("my-element/background.svg"); }</style>
           <div style="position: absolute;"></div>
           </template>
           </dom-module>
-          <script>Polymer({is: "my-element"})</script></body></html>
+          <script>Polymer({is: "my-element"})</script>
         `;
 
-        const ast = parse5.parse(html);
+        const ast = astUtils.parse(html);
         importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath);
 
         const actual = parse5.serialize(ast);
@@ -113,18 +114,18 @@ suite('import-utils', () => {
         `;
 
         const expected = `
-          <html><head><link rel="import" href="polymer/polymer.html">
+          <link rel="import" href="polymer/polymer.html">
           <link rel="stylesheet" href="my-element/my-element.css">
-          </head><body><dom-module id="my-element" assetpath="my-element/">
+          <dom-module id="my-element" assetpath="my-element/">
           <template>
           <style>:host { background-image: url("my-element/background.svg"); }</style>
           <div style="position: absolute;"></div>
           </template>
           </dom-module>
-          <script>Polymer({is: "my-element"})</script></body></html>
+          <script>Polymer({is: "my-element"})</script>
         `;
 
-        const ast = parse5.parse(html);
+        const ast = astUtils.parse(html);
         importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath, true);
 
         const actual = parse5.serialize(ast);
@@ -134,13 +135,11 @@ suite('import-utils', () => {
 
     test('Leave Templated URLs', () => {
       const base = `
-        <html><head></head><body>
         <a href="{{foo}}"></a>
         <img src="[[bar]]">
-        </body></html>
       `;
 
-      const ast = parse5.parse(base);
+      const ast = astUtils.parse(base);
       importUtils.rewriteAstBaseUrl(ast, importDocPath, mainDocPath);
 
       const actual = parse5.serialize(ast);
@@ -165,20 +164,17 @@ suite('import-utils', () => {
         <script>Polymer({is: "my-element"})</script>`;
 
       const expectedBase = `
-        <html><head>
         <link rel="import" href="components/polymer/polymer.html">
         <link rel="stylesheet" href="components/my-element/my-element.css">
-        </head><body>
         <dom-module id="my-element" assetpath="components/my-element/">
         <template>
         <style>:host { background-image: url("components/my-element/background.svg"); }</style>
         <img src="components/my-element/bloop.gif">
         </template>
         </dom-module>
-        <script>Polymer({is: "my-element"})</script>
-        </body></html>`;
+        <script>Polymer({is: "my-element"})</script>`;
 
-      const ast = parse5.parse(htmlBase);
+      const ast = astUtils.parse(htmlBase);
       importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url', true);
 
       const actual = parse5.serialize(ast);
@@ -202,19 +198,18 @@ suite('import-utils', () => {
       `;
 
       const expectedBase = `
-        <html><head>
         <link rel="import" href="polymer/polymer.html">
         <link rel="stylesheet" href="components/my-element.css">
-        </head><body><dom-module id="my-element" assetpath="components/">
+        <dom-module id="my-element" assetpath="components/">
         <template>
         <style>:host { background-image: url("components/background.svg"); }</style>
         <img src="components/bloop.gif">
         </template>
         </dom-module>
-        <script>Polymer({is: "my-element"})</script></body></html>
+        <script>Polymer({is: "my-element"})</script>
       `;
 
-      const ast = parse5.parse(htmlBase);
+      const ast = astUtils.parse(htmlBase);
       importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url', true);
 
       const actual = parse5.serialize(ast);
@@ -232,17 +227,14 @@ suite('import-utils', () => {
       `;
 
       const expectedBase = `
-        <html><head>
-        </head><body>
         <a href="foo.html" target="_blank">LINK</a>
         <a href="bar.html" target="leavemealone">OTHERLINK</a>
         <form action="doit" target="_blank"></form>
         <form action="doitagain" target="leavemealone"></form>
         <div>Just a div.  I don't need a target</div>
-        </body></html>
       `;
 
-      const ast = parse5.parse(htmlBase);
+      const ast = astUtils.parse(htmlBase);
       importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url');
 
       const actual = parse5.serialize(ast);


### PR DESCRIPTION
Don't add unwanted `html`, `head`, and `body` tags to bundled documents if they don't have them to begin with.

This fixes `polymer-bundler`'s contribution to the problem encountered here https://github.com/Polymer/polymer-build/issues/173 though `polymer-build`'s joiner contains cases where `polymer-build` still needs to be fixed.

 - [x] CHANGELOG.md has been updated