### PR TITLE
Spring cleaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,
   use new public method `generateManifest()`.
@@ -25,6 +24,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   https://www.polymer-project.org/2.0/docs/tools/node-support
 - Fixed an issue where bundler was adding `<html>`, `<head>`, and `<body>` tags
   to documents that didn't have them.
+- Removed unused/not-implemented options from the CLI and bundler.
+- Corrected the CLI usage output.
+- Corrected the README.
 
 ## 2.0.0-pre.11 - 2017-03-20
 - Bump dependency on analyzer
@@ -38,7 +40,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump dependency on analyzer
 
 ## 2.0.0-pre.8 - 2017-03-03
-
 - Uses `polymer-analyzer` directly to obtain import document sources and
   ASTs.  This enforces agreement with the Analyzer as to which documents
   should be inlined/bundled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   (https://www.polymer-project.org/2.0/docs/tools/node-support) for details.
 - Fixed an issue where bundler was adding `<html>`, `<head>`, and `<body>` tags
   to documents that didn't have them.
-- Removed unused/not-implemented options from the CLI and bundler.
+- Removed unused/not-implemented options from the polymer-bundler CLI and
+  corresponding `Bundler` options: `strip-exclude`, `no-implicit-strip` and
+  `redirect`.
 - Corrected the CLI usage output.
 - Corrected the README.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bump dependency on analyzer
 
 ## 2.0.0-pre.10 - 2017-03-15
-
 - Add a sourcemap option to properly handle or create sourcemaps for
   script tags
 

--- a/README.md
+++ b/README.md
@@ -113,14 +113,14 @@ bundler.generateManifest([target]).then((manifest) => {
   bundler.bundle(manifest).then((bundles) => {
     /**
       * do stuff here
-      */      
+      */
   });
 });
 ```
 
 ## Caveats
 
-Because HTML Imports changes the order of execution scripts can have, polymer-bundler has to make a few compromises to achieve that same script 
+Because HTML Imports changes the order of execution scripts can have, polymer-bundler has to make a few compromises to achieve that same script
 execution order.
 
 1. Contents of all HTML Import documents will be moved to `<body>`

--- a/README.md
+++ b/README.md
@@ -120,8 +120,7 @@ bundler.generateManifest([target]).then((manifest) => {
 
 ## Caveats
 
-Because HTML Imports changes the order of execution scripts can have, polymer-bundler has to make a few compromises to achieve that same script
-execution order.
+In order to inlining the contents of HTML Import documents into the bundle, `polymer-bundler` has to make a few compromises to preserve valid HTML structure, script execution and style rule order:
 
 1. Contents of all HTML Import documents will be moved to `<body>`
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/parse5": "^2.2.33",
     "@types/source-map": "^0.5.0",
     "chai": "^3.5.0",
-    "clang-format": "^1.0.42",
+    "clang-format": "=1.0.49",
     "eslint": "^2.8.0",
     "firebase": "^2.4.1",
     "mocha": "^2.2.4",

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -43,30 +43,10 @@ const optionDefinitions = [
         'Exclude a subpath from root. Use multiple times to exclude multiple paths. Tags to excluded paths are kept'
   },
   {
-    name: 'redirect',
-    type: String,
-    multiple: true,
-    description:
-        'Takes an argument in the form of URI|PATH where url is a URI composed of a protocol, hostname, and path and PATH is a local filesystem path to replace the matched URI part with. Multiple redirects may be specified; the earliest ones have the highest priority.'
-  },
-  {
-    name: 'strip-exclude',
-    type: String,
-    multiple: true,
-    description: 'Exclude a subpath and strip the link that includes it',
-    typeLabel: `${pathArgument}`
-  },
-  {
     name: 'strip-comments',
     type: Boolean,
     description:
         'Strips all HTML comments not containing an @license from the document'
-  },
-  {
-    name: 'no-implicit-strip',
-    type: Boolean,
-    description:
-        'DANGEROUS! Avoid stripping imports of the transitive dependencies of imports specified with `--exclude`. May result in duplicate javascript inlining.'
   },
   {
     name: 'inline-scripts',
@@ -177,8 +157,6 @@ if (options.help || !entrypoints) {
 }
 
 options.excludes = options.exclude || [];
-options.redirects = options.redirect || [];
-options.stripExcludes = options['strip-exclude'] || [];
 options.stripComments = options['strip-comments'];
 options.implicitStrip = !options['no-implicit-strip'];
 options.inlineScripts = options['inline-scripts'];

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -177,7 +177,7 @@ function documentCollectionToManifestJson(documents: DocumentCollection):
   return manifest;
 }
 
-(async() => {
+(async () => {
   const bundler = new Bundler(options);
   let bundles: DocumentCollection;
   try {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -29,12 +29,6 @@ import * as urlUtils from './url-utils';
 import {UrlString} from './url-utils';
 
 
-// TODO(usergenic): resolve <base> tags.
-// TODO(garlicnation): find transitive dependencies of specified excluded files.
-// TODO(garlicnation): ignore <link> in <template>
-// TODO(garlicnation): Add noopResolver for external urls.
-// TODO(garlicnation): Add noopResolver for excluded urls.
-// TODO(garlicnation): Add redirectResolver for fakeprotocol:// urls
 // TODO(usergenic): Add plylog
 export interface Options {
   // The instance of the Polymer Analyzer which has completed analysis
@@ -42,12 +36,6 @@ export interface Options {
 
   // URLs of files that should not be inlined.
   excludes?: UrlString[];
-
-  // *DANGEROUS*! Avoid stripping imports of the transitive dependencies of
-  // excluded imports (i.e. where listed in `excludes` option or where contained
-  // in a folder/descendant of the `excludes` array.)  May result in duplicate
-  // javascript inlining.
-  noImplicitStrip?: boolean;
 
   // When true, inline external CSS file contents into <style> tags in the
   // output document.
@@ -66,10 +54,6 @@ export interface Options {
 
   // Remove of all comments (except those containing '@license') when true.
   stripComments?: boolean;
-
-  // URLs of files that should not be inlined and which should have all links
-  // removed.
-  stripExcludes?: UrlString[];
 }
 
 export interface BundleResult {
@@ -82,11 +66,9 @@ export class Bundler {
   enableCssInlining: boolean;
   enableScriptInlining: boolean;
   excludes: UrlString[];
-  implicitStrip: boolean;
   rewriteUrlsInTemplates: boolean;
   sourcemaps: boolean;
   stripComments: boolean;
-  stripExcludes: UrlString[];
 
   private _overlayUrlLoader: InMemoryOverlayUrlLoader;
 
@@ -107,8 +89,6 @@ export class Bundler {
       this.analyzer = new Analyzer({urlLoader: this._overlayUrlLoader});
     }
 
-    // implicitStrip should be true by default
-    this.implicitStrip = !Boolean(opts.noImplicitStrip);
     this.excludes = Array.isArray(opts.excludes) ? opts.excludes : [];
     this.stripComments = Boolean(opts.stripComments);
     this.enableCssInlining = Boolean(opts.inlineCss);

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -31,8 +31,8 @@ const inlineSourceMapExpr =
 
 
 function base64StringToRawSourceMap(input: string) {
-  return JSON.parse(
-      Buffer.from(input, 'base64').toString('utf8')) as RawSourceMap;
+  return JSON.parse(Buffer.from(input, 'base64').toString('utf8')) as
+      RawSourceMap;
 }
 
 function rawSourceMapToBase64String(sourcemap: RawSourceMap) {

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -344,27 +344,6 @@ suite('Bundler', () => {
       assert.equal(imports.length, 1);
     });
 
-    const cssFromExclude = preds.AND(
-        preds.hasTagName('link'),
-        preds.hasAttrValue('rel', 'import'),
-        preds.hasAttrValue('type', 'css'));
-
-    test.skip(
-        'Excluded imports are not inlined when behind a redirected URL.',
-        async () => {
-          const options = {
-            // TODO(usergenic): use non-redirected form of URL (?)
-            excludes: ['test/html/imports/simple-import.html'],
-            redirects: ['red://herring/at|test/html/imports']
-          };
-          const doc = await bundle(
-              path.resolve('test/html/custom-protocol-excluded.html'), options);
-          const imports = dom5.queryAll(doc, htmlImport);
-          assert.equal(imports.length, 2);
-          const badCss = dom5.queryAll(doc, cssFromExclude);
-          assert.equal(badCss.length, 0);
-        });
-
     test.skip('Excluded CSS is not inlined', async () => {
       const doc = await bundle(
           inputPath, {inlineCss: true, excludes: ['imports/simple-style.css']});

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -304,20 +304,6 @@ suite('Bundler', () => {
     });
   });
 
-  suite('Redirect', () => {
-
-    test('Redirected paths load properly', async () => {
-      const options = {
-        redirects:
-            ['chrome://imports/|test/html/imports/', 'biz://cool/|test/html']
-      };
-      const doc = await bundle('test/html/custom-protocol.html', options);
-      assert(doc);
-    });
-
-    // TODO(usergenic): Add tests here to demo common use case of alt domains.
-  });
-
   suite('Absolute paths in URLs', () => {
 
     test('will be resolved by the analyzer', async () => {
@@ -329,7 +315,7 @@ suite('Bundler', () => {
     });
   });
 
-  suite('excludes', () => {
+  suite('Excludes', () => {
 
     const excluded = preds.AND(
         preds.hasTagName('link'),

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -21,8 +21,7 @@ import * as path from 'path';
 import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
 
 import {Bundle} from '../bundle-manifest';
-import {Bundler} from '../bundler';
-import {Options as BundlerOptions} from '../bundler';
+import {Bundler, Options as BundlerOptions} from '../bundler';
 
 chai.config.showDiff = true;
 

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -330,10 +330,7 @@ suite('Bundler', () => {
     });
   });
 
-  suite('Excludes', () => {
-
-    const htmlImport = preds.AND(
-        preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
+  suite('excludes', () => {
 
     const excluded = preds.AND(
         preds.hasTagName('link'),
@@ -369,18 +366,10 @@ suite('Bundler', () => {
           assert.equal(badCss.length, 0);
         });
 
-    test('Excluded imports with "Strip Excludes" are removed', async () => {
-      const options = {stripExcludes: excludes};
-      const doc = await bundle(inputPath, options);
-      const imports = dom5.queryAll(doc, excluded);
-      assert.equal(imports.length, 0);
-    });
-
-    test('Strip Excludes does not have to be exact', async () => {
-      const options = {stripExcludes: ['simple-import']};
-      const doc = await bundle(inputPath, options);
-      const imports = dom5.queryAll(doc, excluded);
-      assert.equal(imports.length, 0);
+    test.skip('Excluded CSS is not inlined', async () => {
+      const doc = await bundle(
+          inputPath, {inlineCss: true, excludes: ['imports/simple-style.css']});
+      assert.include(parse5.serialize(doc), 'href="imports/simple-style.css"');
     });
 
     test('Excluded comments are removed', async () => {

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -24,7 +24,7 @@ const assert = chai.assert;
 
 suite('polymer-bundler CLI', () => {
 
-  test('uses the current working folder as loader root', async() => {
+  test('uses the current working folder as loader root', async () => {
     const projectRoot = path.resolve(__dirname, '../../test/html');
     const cli = path.resolve(__dirname, '../bin/polymer-bundler.js');
     const stdout =

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -68,7 +68,7 @@ suite('Bundler', () => {
   }
 
   suite('Sharded builds', () => {
-    test('with 3 entrypoints, all deps are in their places', async() => {
+    test('with 3 entrypoints, all deps are in their places', async () => {
       const strategy = generateSharedDepsMergeStrategy(2);
       const docs =
           await bundleMultiple([common, entrypoint1, entrypoint2], strategy);
@@ -97,7 +97,7 @@ suite('Bundler', () => {
           entrypoint2Doc, [elTwo, depTwo], [commonModule, elOne, depOne]);
     });
 
-    test('with 2 entrypoints and shell, all deps in their places', async() => {
+    test('with 2 entrypoints and shell, all deps in their places', async () => {
       const strategy = generateShellMergeStrategy(shell, 2);
       const docs =
           await bundleMultiple([shell, entrypoint1, entrypoint2], strategy);

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -87,7 +87,7 @@ suite('Bundler', () => {
 
   suite('Sourcemaps', () => {
 
-    test('inline', async() => {
+    test('inline', async () => {
       const doc = await bundle(
           'inline.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});
@@ -109,7 +109,7 @@ suite('Bundler', () => {
       }
     });
 
-    test('external', async() => {
+    test('external', async () => {
       const doc = await bundle(
           'external.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});
@@ -127,7 +127,7 @@ suite('Bundler', () => {
       }
     });
 
-    test('combined', async() => {
+    test('combined', async () => {
       const doc = await bundle(
           'combined.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});
@@ -145,7 +145,7 @@ suite('Bundler', () => {
       }
     });
 
-    test('invalid existing', async() => {
+    test('invalid existing', async () => {
       const doc = await bundle(
           'invalid.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -145,7 +145,7 @@ suite('Bundler', () => {
       }
     });
 
-    test('invalid existing', async () => {
+    test('invalid maps are compiled correctly', async () => {
       const doc = await bundle(
           'invalid.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -87,7 +87,7 @@ suite('Bundler', () => {
 
   suite('Sourcemaps', () => {
 
-    test('inline', async () => {
+    test('inline maps are compiled correctly', async () => {
       const doc = await bundle(
           'inline.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});
@@ -109,7 +109,7 @@ suite('Bundler', () => {
       }
     });
 
-    test('external', async () => {
+    test('external map files are compiled correctly', async () => {
       const doc = await bundle(
           'external.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});
@@ -127,7 +127,7 @@ suite('Bundler', () => {
       }
     });
 
-    test('combined', async () => {
+    test('mix of inline and external maps are compiled correctly', async () => {
       const doc = await bundle(
           'combined.html',
           {inlineScripts: true, sourcemaps: true, analyzer: analyzer});

--- a/test/html/imports/simple-import.html
+++ b/test/html/imports/simple-import.html
@@ -8,24 +8,24 @@
     subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <dom-module id="my-element">
-  <!--
+<!--
     This comment exists to be stripped.
-  -->
-  <link rel="import" type="css" href="simple-style.css">
-  <template>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630">
-      <rect x="0" y="0" width="630" height="630" fill="#3c790a" />
-      <path d="m212 497c11" />
-      <polygon />
-      <path />
-      <polygon/>
-      <path />
-    </svg>
-  </template>
+-->
+<link rel="import" type="css" href="simple-style.css">
+<template>
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630">
+    <rect x="0" y="0" width="630" height="630" fill="#3c790a" />
+    <path d="m212 497c11" />
+    <polygon />
+    <path />
+    <polygon/>
+    <path />
+  </svg>
+</template>
 </dom-module>
 <script>
   Polymer({
     is: 'my-element'
   });
-
 </script>
+

--- a/test/html/imports/simple-import.html
+++ b/test/html/imports/simple-import.html
@@ -8,23 +8,24 @@
     subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
 <dom-module id="my-element">
-<!--
+  <!--
     This comment exists to be stripped.
--->
+  -->
   <link rel="import" type="css" href="simple-style.css">
   <template>
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630">
-    <rect x="0" y="0" width="630" height="630" fill="#3c790a"/>
-    <path d="m212 497c11"/>
-    <polygon />
-    <path />
-    <polygon/>
-    <path />
-  </svg>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630">
+      <rect x="0" y="0" width="630" height="630" fill="#3c790a" />
+      <path d="m212 497c11" />
+      <polygon />
+      <path />
+      <polygon/>
+      <path />
+    </svg>
   </template>
 </dom-module>
 <script>
   Polymer({
     is: 'my-element'
   });
+
 </script>

--- a/test/html/imports/simple-import.html
+++ b/test/html/imports/simple-import.html
@@ -11,17 +11,17 @@
 <!--
     This comment exists to be stripped.
 -->
-<link rel="import" type="css" href="simple-style.css">
-<template>
+  <link rel="import" type="css" href="simple-style.css">
+  <template>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630">
-    <rect x="0" y="0" width="630" height="630" fill="#3c790a" />
-    <path d="m212 497c11" />
+    <rect x="0" y="0" width="630" height="630" fill="#3c790a"/>
+    <path d="m212 497c11"/>
     <polygon />
     <path />
     <polygon/>
     <path />
   </svg>
-</template>
+  </template>
 </dom-module>
 <script>
   Polymer({

--- a/test/html/imports/simple-import.html
+++ b/test/html/imports/simple-import.html
@@ -28,4 +28,3 @@
     is: 'my-element'
   });
 </script>
-


### PR DESCRIPTION
 - Removed unimplemented options from the `polymer-bundler.js` CLI
 - Removed tests that didn't prove anything about those unimplemented options
 - Ran clang-format after pinning it to 1.0.49
 - Cleaned up minor README and CHANGELOG formatting issues.
 - Removed obsolete TODOs.
 - [x] CHANGELOG.md has been updated
