### PR TITLE
Updated CHANGELOG for new 2.0.0-pre.12 version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 2.0.0-pre.12 - 2017-04-14
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,
   use new public method `generateManifest()`.


### PR DESCRIPTION
I need to get polymer-build to use this in order to fix some build -> bundler pipeline bugs, so this has to get released.  There are a lot of changes to bundler since last release:

- BREAKING: Public API change.  The `bundle()` method now takes a manifest
  instead of entrypoints, strategy and mapper.  To produce a manifest,
  use new public method `generateManifest()`.
- The polymer-bundler CLI now uses the current working directory as
  the package root folder for its Analyzer, allowing absolute paths to
  resolve properly.
- Fixed an issue where an immediate `<style>` child of `<dom-module>` was
  not moved into generated `<template>`.
- BREAKING: Added option `rewriteUrlsInTemplates` to support rewriting of urls
  found in `src`, `href`, `action`, `assetpath` and `style` attributes
  found inside `<template>` elements, when inlining html imports.  Previously,
  this was done by default.  Now requires explicit option.
- BREAKING: inlinining functions in `import-utils` require an explicit
 `analyzer` argument.
- BREAKING: Dropped support for node v4, added support for node v8. See our
  [node version support policy]
  (https://www.polymer-project.org/2.0/docs/tools/node-support) for details.
- Fixed an issue where bundler was adding `<html>`, `<head>`, and `<body>` tags
  to documents that didn't have them.
- Removed unused/not-implemented options from the polymer-bundler CLI and
  corresponding `Bundler` options: `strip-exclude`, `no-implicit-strip` and
  `redirect`.
- Corrected the CLI usage output.
- Corrected the README.
- [x] CHANGELOG.md has been updated
