### PR TITLE
Bundle url mapper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Added new url mapper functions to make customizing destination of shared
+  bundle files easier: `generateSharedBundleUrlMapper` and
+  `generateCountingSharedBundleUrlMapper` in `src/build-manifest`.
+
 ## 2.0.0-pre.13 - 2017-05-01
 - BREAKING: Bundler now supports "lazy imports" aka `<link rel="lazy-import">`.
   URLs which are imported lazily are implicitly treated as entrypoints.  This


### PR DESCRIPTION
https://github.com/Polymer/polymer-build/pull/189 opens the ability for users to provide options to the `PolymerProject#bundler()` method, opening up customized build strategies and opportunities.  One of the important elements of customization was allowing users to redefine where shared bundles go (https://github.com/Polymer/polymer-bundler/issues/437)

That behavior was hardwired into the default `BundleUrlMapper` used called `sharedBundleUrlMapper`. We were missing a friendly option for users to define their own bundle url mappers for shared bundles.  This adds those functions and factors out the layers of bundler url mapping.

Getting this released will also make it easier to write and read tests to demonstrate behavior of providing options added in https://github.com/Polymer/polymer-build/pull/189 as well as support more readable coverage per https://github.com/Polymer/polymer-bundler/issues/482.

 - [x] CHANGELOG.md has been updated
 - [x] README.md has been updated
