### PR TITLE
Fixed bug where exclude did not support folders.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Fixed an issue where `exclude` option did not actually support folder names.
+
 ## 2.0.0-pre.12 - 2017-04-14
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ polymer-bundler as a library has two exported function.
 
 `polymer-bundler` constructor takes an object of options similar to the command line options:
 
-- `excludes`: An array of strings with regular expressions to exclude paths from being inlined.
+- `excludes`: URLs to exclude from inlining. URLs may represent files or folders. HTML tags referencing excluded URLs are preserved.
 - `inlineCss`: Inline external stylesheets.
 - `inlineScripts`: Inline external scripts.
 - `sourcemaps`: Honor (or create) sourcemaps for inline scripts

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -40,7 +40,7 @@ const optionDefinitions = [
     type: String,
     multiple: true,
     description:
-        'Exclude a subpath from root. Use multiple times to exclude multiple paths. Tags to excluded paths are kept'
+        'URL to exclude from inlining. Use multiple times to exclude multiple files and folders. HTML tags referencing excluded URLs are preserved.'
   },
   {
     name: 'strip-comments',

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -282,6 +282,12 @@ export class Bundler {
     for (const bundle of bundles) {
       for (const exclude of this.excludes) {
         bundle.files.delete(exclude);
+        const excludeAsFolder = exclude.endsWith('/') ? exclude : exclude + '/';
+        for (const file of bundle.files) {
+          if (file.startsWith(excludeAsFolder)) {
+            bundle.files.delete(file);
+          }
+        }
       }
     }
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -34,7 +34,8 @@ export interface Options {
   // The instance of the Polymer Analyzer which has completed analysis
   analyzer?: Analyzer;
 
-  // URLs of files that should not be inlined.
+  // URLs of files and/or folders that should not be inlined. HTML tags
+  // referencing excluded URLs are preserved.'
   excludes?: UrlString[];
 
   // When true, inline external CSS file contents into <style> tags in the

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -380,7 +380,7 @@ suite('Bundler', () => {
     test('Folder can be excluded', async () => {
       const linkMatcher = preds.AND(
           preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
-      const options = {excludes: ['test/html/imports/']};
+      const options = {excludes: ['imports/']};
       const doc = await bundle('test/html/default.html', options);
       const links = dom5.queryAll(doc, linkMatcher);
       // one duplicate import is removed.  default.html contains this
@@ -388,6 +388,8 @@ suite('Bundler', () => {
       //     <link rel="import" href="imports/simple-import.html">
       //     <link rel="import" href="imports/simple-import.html">
       assert.equal(links.length, 1);
+      assert.equal(
+          dom5.getAttribute(links[0]!, 'href'), 'imports/simple-import.html');
     });
   });
 


### PR DESCRIPTION
 - Updated the code that filters out excluded html files to include the folder name case.
 - There was a test which was a false positive because it was actually a `<link rel="import" type="css" href="simple-style.css">` that was brought in from an inlined html file that was intended to be excluded.  Fixed the test.
 - [x] CHANGELOG.md has been updated
