### PR TITLE
Inline Scripts and CSS by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Bundler now inlines scripts and css by default.  Pass `inlineCss` and
+  `inlineScripts` as `false` explicitly to disable.
+
 ## 2.0.0-pre.12 - 2017-04-14
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -90,8 +90,10 @@ export class Bundler {
 
     this.excludes = Array.isArray(opts.excludes) ? opts.excludes : [];
     this.stripComments = Boolean(opts.stripComments);
-    this.enableCssInlining = Boolean(opts.inlineCss);
-    this.enableScriptInlining = Boolean(opts.inlineScripts);
+    this.enableCssInlining =
+        Boolean(typeof opts.inlineCss === 'undefined' || opts.inlineCss);
+    this.enableScriptInlining = Boolean(
+        typeof opts.inlineScripts === 'undefined' || opts.inlineScripts);
     this.rewriteUrlsInTemplates = Boolean(opts.rewriteUrlsInTemplates);
     this.sourcemaps = Boolean(opts.sourcemaps);
   }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -91,9 +91,9 @@ export class Bundler {
     this.excludes = Array.isArray(opts.excludes) ? opts.excludes : [];
     this.stripComments = Boolean(opts.stripComments);
     this.enableCssInlining =
-        Boolean(typeof opts.inlineCss === 'undefined' || opts.inlineCss);
-    this.enableScriptInlining = Boolean(
-        typeof opts.inlineScripts === 'undefined' || opts.inlineScripts);
+        opts.inlineCss === undefined ? true : opts.inlineCss;
+    this.enableScriptInlining =
+        opts.inlineScripts === undefined ? true : opts.inlineScripts;
     this.rewriteUrlsInTemplates = Boolean(opts.rewriteUrlsInTemplates);
     this.sourcemaps = Boolean(opts.sourcemaps);
   }

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -159,8 +159,9 @@ suite('Bundler', () => {
   });
 
   test('svg is nested correctly', async () => {
+    const opts = {inlineScripts: false, inlineCss: false};
     const svg =
-        dom5.query(await bundle(inputPath), matchers.template)!['content']
+        dom5.query(await bundle(inputPath, opts), matchers.template)!['content']
             .childNodes[1];
     assert.equal(svg.childNodes!.filter(dom5.isElement).length, 6);
   });
@@ -219,9 +220,10 @@ suite('Bundler', () => {
     assert.equal(bodyContainer, divActual);
   });
 
-  test('Scripts are not inlined by default', async () => {
+  test('Scripts are not inlined if specified', async () => {
     const scripts = dom5.queryAll(
-        await bundle('test/html/external.html'), matchers.externalJavascript);
+        await bundle('test/html/external.html', {inlineScripts: false}),
+        matchers.externalJavascript);
     assert.isAbove(scripts.length, 0, 'scripts were inlined');
     scripts.forEach(function(s) {
       assert.equal(dom5.getTextContent(s), '', 'script src should be empty');
@@ -248,7 +250,8 @@ suite('Bundler', () => {
   suite('Script Ordering', () => {
 
     test('Imports and scripts are ordered correctly', async () => {
-      const doc = await bundle('test/html/order-test.html');
+      const doc =
+          await bundle('test/html/order-test.html', {inlineScripts: false});
 
       const expectedOrder = [
         'first-script',


### PR DESCRIPTION
In pretty much every example where bundler is used programmatically, we pass in `inlineCss` and `inlineScripts` as `true`.

It feels like we should just be doing this by default.

What do you think?

(Note: base of this PR is a branch with a fix that hasn't been merged to master yet for the `exclude-as-folder` behavior.  This is due to an tangential bug in the test that gets triggered when inlining is default behavior.)