### PR TITLE
Mutable manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- `BundleManifest` will now look up a `Bundle` by its `files` even after the
+  `files` property has been mutated.  Supports post-processing of manifest
+  which may be much simpler that embedding some kinds of manipulation inside
+  `strategy` functions.  Notably, this enables users to emulate the old
+  `add-import` behavior by updating a target bundle.
+
 ## 2.0.0-pre.12 - 2017-04-14
 - BREAKING: Public API change.  The `bundle()` method now takes a manifest
   instead of entrypoints, strategy and mapper.  To produce a manifest,

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -58,7 +58,10 @@ export class AssignedBundle {
 }
 
 /**
- * A bundle manifest is a mapping of urls to bundles.
+ * A bundle manifest is a mapping of distinct urls to bundles.  A bundle's
+ * `files` property may be modified after the manifest is created, but it
+ * is always expected that no two bundles within the same manifest will
+ * contain the same file url.
  */
 export class BundleManifest {
   // Map of bundle url to bundle.
@@ -72,10 +75,13 @@ export class BundleManifest {
     this.bundles = urlMapper(Array.from(bundles));
   }
 
-  // Convenience method to return a bundle for a constituent file url.
+  /**
+   * Returns the url and bundle when a bundle is found containing the
+   * specified file url.
+   */
   getBundleForFile(fileUrl: UrlString): AssignedBundle|undefined {
     for (const [bundleUrl, bundle] of this.bundles) {
-      if (this.bundles.get(bundleUrl)!.files.has(fileUrl)) {
+      if (bundle.files.has(fileUrl)) {
         return {bundle: bundle, url: bundleUrl};
       }
     }

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -58,18 +58,21 @@ export class AssignedBundle {
 }
 
 /**
- * A bundle manifest is a mapping of distinct urls to bundles.  A bundle's
- * `files` property may be modified after the manifest is created, but it
- * is always expected that no two bundles within the same manifest will
- * contain the same file url.
+ * A bundle manifest is a mapping of distinct urls to bundles and acts as
+ * a specification for the bundle operation.
  */
 export class BundleManifest {
-  // Map of bundle url to bundle.
+  /**
+   * Map of bundle url to bundle. bundle's `files` property may be modified
+   * after the manifest is created, but it is always expected that no two
+   * bundles within the same manifest will contain the same file url.
+   */
   bundles: Map<UrlString, Bundle>;
 
   /**
-   * Given a collection of bundles and a BundleUrlMapper to generate urls for
-   * them, the constructor populates the `bundles` map.
+   * Given a collection of bundles and a `BundleUrlMapper` to generate urls
+   * for them, the constructor populates the `bundles` map.  Files in a
+   * bundle should be unique to that bundle.
    */
   constructor(bundles: Bundle[], urlMapper: BundleUrlMapper) {
     this.bundles = urlMapper(Array.from(bundles));

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -64,32 +64,20 @@ export class BundleManifest {
   // Map of bundle url to bundle.
   bundles: Map<UrlString, Bundle>;
 
-  // Map of file url to bundle url.
-  private _bundleUrlForFile: Map<UrlString, UrlString>;
-
   /**
    * Given a collection of bundles and a BundleUrlMapper to generate urls for
-   * them, the constructor populates the `bundles` and `files` index properties.
+   * them, the constructor populates the `bundles` map.
    */
   constructor(bundles: Bundle[], urlMapper: BundleUrlMapper) {
     this.bundles = urlMapper(Array.from(bundles));
-    this._bundleUrlForFile = new Map();
-
-    for (const bundleMapEntry of this.bundles) {
-      const bundleUrl = bundleMapEntry[0];
-      const bundle = bundleMapEntry[1];
-      for (const fileUrl of bundle.files) {
-        console.assert(!this._bundleUrlForFile.has(fileUrl));
-        this._bundleUrlForFile.set(fileUrl, bundleUrl);
-      }
-    }
   }
 
   // Convenience method to return a bundle for a constituent file url.
-  getBundleForFile(url: UrlString): AssignedBundle|undefined {
-    const bundleUrl = this._bundleUrlForFile.get(url);
-    if (bundleUrl) {
-      return {bundle: this.bundles.get(bundleUrl)!, url: bundleUrl};
+  getBundleForFile(fileUrl: UrlString): AssignedBundle|undefined {
+    for (const [bundleUrl, bundle] of this.bundles) {
+      if (this.bundles.get(bundleUrl)!.files.has(fileUrl)) {
+        return {bundle: bundle, url: bundleUrl};
+      }
     }
   }
 }

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -110,6 +110,10 @@ export class Bundler {
     const bundledDocuments: DocumentCollection =
         new Map<string, BundledDocument>();
 
+    // Clone manifest here, to ensure subsequent out-of-band changes to it
+    // do not impact the plan-of-record for the duration of the operation.
+    manifest = clone(manifest);
+
     for (const bundleEntry of manifest.bundles) {
       const bundleUrl = bundleEntry[0];
       const bundle = {url: bundleUrl, bundle: bundleEntry[1]};

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -72,6 +72,12 @@ suite('BundleManifest', () => {
           serializeBundle(manifest.getBundleForFile('E')!.bundle),
           '[A,B]->[E]');
     });
+
+    test('bundles are mutable; you could add a file and then find', () => {
+      const bundleA = manifest.bundles.get('A')!;
+      bundleA.files.add('X');
+      assert.equal(manifest.getBundleForFile('X')!.bundle, bundleA);
+    });
   });
 
   suite('generateBundles', () => {


### PR DESCRIPTION
 - `BundleManifest` will now look up a `Bundle` by its `files` even after the `files` property has been mutated.  Supports post-processing of manifest which may be much simpler that embedding some kinds of manipulation inside `strategy` functions.  Notably, this enables users to emulate the old `add-import` behavior by updating a target bundle.
 - [x] CHANGELOG.md has been updated
 - Sort of fixes https://github.com/Polymer/polymer-bundler/issues/402