### PR TITLE
Lazy imports up in here

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- BREAKING: Bundler now supports "lazy imports" aka `<link rel="lazy-import">`.
+  URLs which are imported lazily are implicitly treated as entrypoints.  This
+  is a breaking change because, previously, Bundler would incorrectly treat
+  lazy imports just like regular imports.
 - BREAKING: Bundler now inlines Scripts and CSS by default.  Pass `inlineCss`
   and `inlineScripts` as `false` explicitly to disable.
 - Fixed an issue where `exclude` option did not actually support folder names.

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -113,8 +113,7 @@ export class Bundler {
     for (const bundleEntry of manifest.bundles) {
       const bundleUrl = bundleEntry[0];
       const bundle = {url: bundleUrl, bundle: bundleEntry[1]};
-      const bundledAst =
-          await this._bundleDocument(bundle, manifest, bundle.bundle.files);
+      const bundledAst = await this._bundleDocument(bundle, manifest);
       bundledDocuments.set(
           bundleUrl, {ast: bundledAst, files: Array.from(bundle.bundle.files)});
     }
@@ -227,10 +226,8 @@ export class Bundler {
    */
   private async _bundleDocument(
       docBundle: AssignedBundle,
-      bundleManifest: BundleManifest,
-      bundleImports?: Set<string>): Promise<ASTNode> {
+      bundleManifest: BundleManifest): Promise<ASTNode> {
     let document = await this._prepareBundleDocument(docBundle);
-
     const ast = clone(document.parsedDocument.ast);
     dom5.removeFakeRootElements(ast);
     this._appendHtmlImportsForBundle(ast, docBundle);

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -68,7 +68,9 @@ export const inlineJavascript: Matcher =
     predicates.AND(predicates.NOT(predicates.hasAttr('src')), jsMatcher);
 export const htmlImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
-    predicates.hasAttrValue('rel', 'import'),
+    predicates.OR(
+        predicates.hasAttrValue('rel', 'import'),
+        predicates.hasAttrValue('rel', 'lazy-import')),
     predicates.hasAttr('href'),
     predicates.OR(
         predicates.hasAttrValue('type', 'text/html'),

--- a/test/html/imports/lazy-imports.html
+++ b/test/html/imports/lazy-imports.html
@@ -1,0 +1,2 @@
+<link rel="lazy-import" href="lazy-imports/lazy-import-1.html">
+<link rel="lazy-import" href="lazy-imports/lazy-import-2.html">

--- a/test/html/imports/lazy-imports/deeply-lazy-import-1.html
+++ b/test/html/imports/lazy-imports/deeply-lazy-import-1.html
@@ -1,0 +1,4 @@
+<link rel="import" href="deeply-lazy-imports-eager-import-1.html">
+<div id="deeply-lazy-import-1">
+  I am so lazy
+</div>

--- a/test/html/imports/lazy-imports/deeply-lazy-imports-eager-import-1.html
+++ b/test/html/imports/lazy-imports/deeply-lazy-imports-eager-import-1.html
@@ -1,0 +1,3 @@
+<div id="deeply-lazy-imports-eager-import-1">
+  I was eagerly imported by a deeply lazy import.
+</div>

--- a/test/html/imports/lazy-imports/lazy-import-1.html
+++ b/test/html/imports/lazy-imports/lazy-import-1.html
@@ -1,0 +1,5 @@
+<link rel="import" href="shared-eager-import-1.html">
+<link rel="lazy-import" href="shared-eager-and-lazy-import-1.html">
+<div id="lazy-import-1">
+  I am lazy import 1
+</div>

--- a/test/html/imports/lazy-imports/lazy-import-2.html
+++ b/test/html/imports/lazy-imports/lazy-import-2.html
@@ -1,0 +1,5 @@
+<link rel="import" href="shared-eager-import-1.html">
+<link rel="import" href="shared-eager-and-lazy-import-1.html">
+<div id="lazy-import-2">
+  I am lazy import 2
+</div>

--- a/test/html/imports/lazy-imports/shared-eager-and-lazy-import-1.html
+++ b/test/html/imports/lazy-imports/shared-eager-and-lazy-import-1.html
@@ -1,0 +1,3 @@
+<div id="shared-eager-and-lazy-import-1">
+  I am imported eagerly and lazily
+</div>

--- a/test/html/imports/lazy-imports/shared-eager-import-1.html
+++ b/test/html/imports/lazy-imports/shared-eager-import-1.html
@@ -1,0 +1,4 @@
+<link rel="import" href="shared-eager-import-2.html">
+<div id="shared-eager-import-1">
+  I am imported by both lazy imports.
+</div>

--- a/test/html/imports/lazy-imports/shared-eager-import-2.html
+++ b/test/html/imports/lazy-imports/shared-eager-import-2.html
@@ -1,0 +1,4 @@
+<link rel="lazy-import" href="deeply-lazy-import-1.html">
+<div id="shared-eager-import-2">
+  I am imported by the shared eager import 1.
+</div>


### PR DESCRIPTION
Rewrote `buildDepsIndex` to do-the-right-thing™ wrt `lazy-import`.

- BREAKING: Bundler now supports "lazy imports" aka `<link rel="lazy-import">`.
  Imports which are lazy-imported are now implicitly treated as entrypoints.
- [x] CHANGELOG.md has been updated
