### PR TITLE
Prepare release 2.0.0 pre.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 2.0.0-pre.13 - 2017-05-01
 - BREAKING: Bundler now supports "lazy imports" aka `<link rel="lazy-import">`.
   URLs which are imported lazily are implicitly treated as entrypoints.  This
   is a breaking change because, previously, Bundler would incorrectly treat

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.2",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "2.0.0-alpha.38",
+    "polymer-analyzer": "2.0.0-alpha.40",
     "source-map": "^0.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
 - [x] CHANGELOG.md has been updated
 - Bumped analyzer up to 2.0.0-alpha.40