### PR TITLE
Exposing bundle url mapper and strategy generator functions right on the polymer-bundler module.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   `generateCountingSharedBundleUrlMapper` in `src/build-manifest`.
 - Fixed an issue where `<link rel="lazy-import">` tags were being moved
   out of their containing `<dom-module>` tags.
+- Export all of the bundle manifest types and functions on the default
+  namespace of `polymer-bundler`.
 
 ## 2.0.0-pre.13 - 2017-05-01
 - BREAKING: Bundler now supports "lazy imports" aka `<link rel="lazy-import">`.

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -28,6 +28,7 @@ import {updateSourcemapLocations} from './source-map';
 import * as urlUtils from './url-utils';
 import {UrlString} from './url-utils';
 
+export * from './bundle-manifest';
 
 // TODO(usergenic): Add plylog
 export interface Options {
@@ -141,7 +142,8 @@ export class Bundler {
       strategy = bundleManifestLib.generateSharedDepsMergeStrategy();
     }
     if (!mapper) {
-      mapper = bundleManifestLib.sharedBundleUrlMapper;
+      mapper = bundleManifestLib.generateCountingSharedBundleUrlMapper(
+          'shared_bundle_');
     }
     const dependencyIndex =
         await depsIndexLib.buildDepsIndex(entrypoints, this.analyzer);

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -16,7 +16,7 @@
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 import * as chai from 'chai';
 
-import {Bundle, BundleManifest, composeStrategies, generateBundles, generateCountingSharedBundleUrlMapper, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedBundleUrlMapper, generateSharedDepsMergeStrategy, generateShellMergeStrategy, invertMultimap, sharedBundleUrlMapper, TransitiveDependenciesMap} from '../bundle-manifest';
+import {Bundle, BundleManifest, composeStrategies, generateBundles, generateCountingSharedBundleUrlMapper, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedBundleUrlMapper, generateSharedDepsMergeStrategy, generateShellMergeStrategy, TransitiveDependenciesMap} from '../bundle-manifest';
 
 chai.config.showDiff = true;
 
@@ -69,13 +69,6 @@ suite('BundleManifest', () => {
           '[A,B]->[E]');
     });
 
-    test('sharedBundleUrlMapper prefixes urls with "shared_bundle_"', () => {
-      const manifest = new BundleManifest(bundles, sharedBundleUrlMapper);
-      assert.equal(
-          serializeBundle(manifest.bundles.get('shared_bundle_1.html')!),
-          '[A,B]->[E]');
-    });
-
     test('generateCountingSharedBundleUrlMapper allows a custom prefix', () => {
       const manifest = new BundleManifest(
           bundles, generateCountingSharedBundleUrlMapper('path/to/shared'));
@@ -103,27 +96,6 @@ suite('BundleManifest', () => {
             '[D]->[D,E]',
             '[F]->[F]'
           ]);
-    });
-  });
-
-  suite('invertMultimap', () => {
-
-    test('produces an index of dependencies and dependent files', () => {
-      const depsIndex = new Map<string, Set<string>>();
-      depsIndex.set('A', new Set(['A', 'B', 'C', 'G']));
-      depsIndex.set('D', new Set(['D', 'B', 'E']));
-      depsIndex.set('F', new Set(['F', 'G']));
-
-      const invertedIndex = invertMultimap(depsIndex);
-      assert.equal(
-          Array.from(invertedIndex.keys()).sort().join(), 'A,B,C,D,E,F,G');
-      assert.equal(Array.from(invertedIndex.get('A')!).join(), 'A');
-      assert.equal(Array.from(invertedIndex.get('B')!).join(), 'A,D');
-      assert.equal(Array.from(invertedIndex.get('C')!).join(), 'A');
-      assert.equal(Array.from(invertedIndex.get('D')!).join(), 'D');
-      assert.equal(Array.from(invertedIndex.get('E')!).join(), 'D');
-      assert.equal(Array.from(invertedIndex.get('F')!).join(), 'F');
-      assert.equal(Array.from(invertedIndex.get('G')!).join(), 'A,F');
     });
   });
 


### PR DESCRIPTION
 - Unexported a couple of methods that are really just utility functions for the existing strategies etc.
 - Sorted the various functions to make it easier to understand what's available.
 - Got rid of the `sharedBundleUrlMapper` constant.  Better to use the generate commands and not have confusing variant sitting around.
 - [x] CHANGELOG.md has been updated
