### PR TITLE
Moved strategy and urlMapper out of the generateManifest function arguments and into the constructor and properties of Bundler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- BREAKING: Bundler options now include `strategy` and `urlMapper`.  These
+  have been moved from the `generateManifest` method which now only takes
+  the `entrypoints` array.
 - Added new url mapper functions to make customizing destination of shared
   bundle files easier: `generateSharedBundleUrlMapper` and
   `generateCountingSharedBundleUrlMapper` in `src/build-manifest`.

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -21,7 +21,7 @@ import * as pathLib from 'path';
 import {Bundler} from '../bundler';
 import {DocumentCollection} from '../document-collection';
 import {UrlString} from '../url-utils';
-import {BundleStrategy, generateShellMergeStrategy} from '../bundle-manifest';
+import {generateShellMergeStrategy} from '../bundle-manifest';
 
 console.warn('polymer-bundler is currently in alpha! Use at your own risk!');
 
@@ -162,6 +162,10 @@ options.implicitStrip = !options['no-implicit-strip'];
 options.inlineScripts = options['inline-scripts'];
 options.inlineCss = options['inline-css'];
 
+if (options.shell) {
+  options.strategy = generateShellMergeStrategy(options.shell, 2);
+}
+
 interface JsonManifest {
   [entrypoint: string]: UrlString[];
 }
@@ -182,14 +186,12 @@ function documentCollectionToManifestJson(documents: DocumentCollection):
   let bundles: DocumentCollection;
   try {
     const shell = options.shell;
-    let strategy: BundleStrategy|undefined;
     if (shell) {
       if (entrypoints.indexOf(shell) === -1) {
         throw new Error('Shell must be provided as `in-html`');
       }
-      strategy = generateShellMergeStrategy(shell, 2);
     }
-    const manifest = await bundler.generateManifest(entrypoints, strategy);
+    const manifest = await bundler.generateManifest(entrypoints);
     bundles = await bundler.bundle(manifest);
   } catch (err) {
     console.log(err);

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -70,17 +70,21 @@ suite('Bundler', () => {
   suite('Applying strategy', () => {
 
     test('inlines css/scripts of html imports added by strategy', async () => {
-      const bundler = new Bundler({inlineCss: true, inlineScripts: true});
-      // This strategy adds a file not in the original document to the bundle.
-      const strategy = (bundles: Bundle[]): Bundle[] => {
-        bundles.forEach((b) => {
-          b.files.add('test/html/imports/external-script.html');
-          b.files.add('test/html/imports/import-linked-style.html');
-        });
-        return bundles;
-      };
+      const bundler = new Bundler({
+        inlineCss: true,
+        inlineScripts: true,
+        // This strategy adds a file not in the original document to the bundle.
+        strategy: (bundles: Bundle[]): Bundle[] => {
+          bundles.forEach((b) => {
+            b.files.add('test/html/imports/external-script.html');
+            b.files.add('test/html/imports/import-linked-style.html');
+          });
+          return bundles;
+        },
+      });
+
       const manifest =
-          await bundler.generateManifest(['test/html/default.html'], strategy);
+          await bundler.generateManifest(['test/html/default.html']);
       const documents = await bundler.bundle(manifest);
       const document = documents.get('test/html/default.html')!;
       assert(document);
@@ -103,20 +107,21 @@ suite('Bundler', () => {
 
     test(
         'changes the href to another bundle if strategy moved it', async () => {
-          const bundler = new Bundler();
-          // This strategy moves a file to a different bundle.
-          const strategy = (bundles: Bundle[]): Bundle[] => {
-            return [
-              new Bundle(
-                  new Set(['test/html/default.html']),
-                  new Set(['test/html/default.html'])),
-              new Bundle(
-                  new Set(),  //
-                  new Set(['test/html/imports/simple-import.html']))
-            ];
-          };
-          const manifest = await bundler.generateManifest(
-              ['test/html/default.html'], strategy);
+          const bundler = new Bundler({
+            // This strategy moves a file to a different bundle.
+            strategy: (bundles: Bundle[]): Bundle[] => {
+              return [
+                new Bundle(
+                    new Set(['test/html/default.html']),
+                    new Set(['test/html/default.html'])),
+                new Bundle(
+                    new Set(),  //
+                    new Set(['test/html/imports/simple-import.html']))
+              ];
+            }
+          });
+          const manifest =
+              await bundler.generateManifest(['test/html/default.html']);
           const documents = await bundler.bundle(manifest);
           const document = documents.get('test/html/default.html')!;
           assert(document);

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -19,7 +19,7 @@ import * as dom5 from 'dom5';
 import * as parse5 from 'parse5';
 import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
 
-import {BundleStrategy, generateSharedDepsMergeStrategy, generateShellMergeStrategy} from '../bundle-manifest';
+import {generateSharedDepsMergeStrategy, generateShellMergeStrategy} from '../bundle-manifest';
 import {Bundler} from '../bundler';
 import {Options as BundlerOptions} from '../bundler';
 import {DocumentCollection} from '../document-collection';
@@ -41,15 +41,14 @@ suite('Bundler', () => {
   const entrypoint1 = 'test/html/shards/shop_style_project/entrypoint1.html';
   const entrypoint2 = 'test/html/shards/shop_style_project/entrypoint2.html';
 
-  async function bundleMultiple(
-      inputPath: string[], strategy: BundleStrategy, opts?: BundlerOptions):
+  async function bundleMultiple(inputPath: string[], opts?: BundlerOptions):
       Promise<DocumentCollection> {
         const bundlerOpts = opts || {};
         if (!bundlerOpts.analyzer) {
           bundlerOpts.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
         }
         bundler = new Bundler(bundlerOpts);
-        const manifest = await bundler.generateManifest(inputPath, strategy);
+        const manifest = await bundler.generateManifest(inputPath);
         return await bundler.bundle(manifest);
       }
 
@@ -69,9 +68,9 @@ suite('Bundler', () => {
 
   suite('Sharded builds', () => {
     test('with 3 entrypoints, all deps are in their places', async () => {
-      const strategy = generateSharedDepsMergeStrategy(2);
-      const docs =
-          await bundleMultiple([common, entrypoint1, entrypoint2], strategy);
+      const docs = await bundleMultiple(
+          [common, entrypoint1, entrypoint2],
+          {strategy: generateSharedDepsMergeStrategy(2)});
       assert.equal(docs.size, 4);
       const commonDoc: parse5.ASTNode = docs.get(common)!.ast;
       assert.isDefined(commonDoc);
@@ -98,9 +97,9 @@ suite('Bundler', () => {
     });
 
     test('with 2 entrypoints and shell, all deps in their places', async () => {
-      const strategy = generateShellMergeStrategy(shell, 2);
-      const docs =
-          await bundleMultiple([shell, entrypoint1, entrypoint2], strategy);
+      const docs = await bundleMultiple(
+          [shell, entrypoint1, entrypoint2],
+          {strategy: generateShellMergeStrategy(shell, 2)});
       assert.equal(docs.size, 3);
       const shellDoc: parse5.ASTNode = docs.get(shell)!.ast;
       assert.isDefined(shellDoc);


### PR DESCRIPTION
 - This is an ergonomic thing that I think ultimately makes it easier to understand how to use Bundler configuration options inside `polymer-build` too.
 - [x] CHANGELOG.md has been updated
