### PR TITLE
Fixed issue where lazy-import tags were being moved around just like eager import tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Added new url mapper functions to make customizing destination of shared
   bundle files easier: `generateSharedBundleUrlMapper` and
   `generateCountingSharedBundleUrlMapper` in `src/build-manifest`.
+- Fixed an issue where `<link rel="lazy-import">` tags were being moved
+  out of their containing `<dom-module>` tags.
 
 ## 2.0.0-pre.13 - 2017-05-01
 - BREAKING: Bundler now supports "lazy imports" aka `<link rel="lazy-import">`.

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -417,7 +417,7 @@ export class Bundler {
     if (!head) {
       return;
     }
-    const firstHtmlImport = dom5.query(head, matchers.htmlImport);
+    const firstHtmlImport = dom5.query(head, matchers.eagerHtmlImport);
     if (!firstHtmlImport) {
       return;
     }

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -76,6 +76,14 @@ export const htmlImport: Matcher = predicates.AND(
         predicates.hasAttrValue('type', 'text/html'),
         predicates.hasAttrValue('type', 'html'),
         predicates.NOT(predicates.hasAttr('type'))));
+export const eagerHtmlImport: Matcher = predicates.AND(
+    predicates.hasTagName('link'),
+    predicates.hasAttrValue('rel', 'import'),
+    predicates.hasAttr('href'),
+    predicates.OR(
+        predicates.hasAttrValue('type', 'text/html'),
+        predicates.hasAttrValue('type', 'html'),
+        predicates.NOT(predicates.hasAttr('type'))));
 export const stylesheetImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
     predicates.hasAttrValue('rel', 'import'),

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -171,6 +171,17 @@ suite('Bundler', () => {
         dom5.queryAll(await bundle(inputPath), matchers.hiddenDiv).length, 1);
   });
 
+  test('lazy imports are not moved', async () => {
+    assert.equal(
+        dom5.queryAll(
+                await bundle('test/html/imports/lazy-imports.html'),
+                preds.AND(
+                    preds.parentMatches(preds.hasTagName('dom-module')),
+                    matchers.htmlImport))
+            .length,
+        2);
+  });
+
   test('dom-modules have assetpath', async () => {
     const assetpath = preds.AND(
         preds.hasTagName('dom-module'),
@@ -196,11 +207,11 @@ suite('Bundler', () => {
         parse5.serialize(documents.get('lazy-imports.html')!.ast);
     assert.include(
         lazyImports,
-        '<link rel="lazy-import" href="lazy-imports/lazy-import-1.html">',
+        '<link rel="lazy-import" group="one" href="lazy-imports/lazy-import-1.html">',
         'lazy-imports.html should keep link to lazy-import-1.html');
     assert.include(
         lazyImports,
-        '<link rel="lazy-import" href="lazy-imports/lazy-import-2.html">',
+        '<link rel="lazy-import" group="two" href="lazy-imports/lazy-import-2.html">',
         'lazy-imports.html should keep link to lazy-import-2.html');
 
     const lazyImport1 =

--- a/test/html/imports/lazy-imports.html
+++ b/test/html/imports/lazy-imports.html
@@ -1,2 +1,4 @@
-<link rel="lazy-import" href="lazy-imports/lazy-import-1.html">
-<link rel="lazy-import" href="lazy-imports/lazy-import-2.html">
+<dom-module id="lazy-app">
+  <link rel="lazy-import" group="one" href="lazy-imports/lazy-import-1.html">
+  <link rel="lazy-import" group="two" href="lazy-imports/lazy-import-2.html">
+</dom-module>


### PR DESCRIPTION
 - The code that moves around links into the hidden div was including lazy-import links because they are html imports.  That was bad and has been fixed.
 - [x] CHANGELOG.md has been updated
