### PR TITLE
Update CHANGELOG and upgrade analyzer for 2.0.0-pre.15 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
 
 <!-- Add new, unreleased changes here. -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+<!-- Add new, unreleased changes here. -->
+
 ## 2.0.0-pre.15 - 2017-05-08
 - Fixed case where an inlined import's `<link rel="lazy-import">` tags
   were being moved.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+## 2.0.0-pre.15 - 2017-05-08
 - Fixed case where an inlined import's `<link rel="lazy-import">` tags
   were being moved.
+- Updated `polymer-analyzer` to latest version.
 
 ## 2.0.0-pre.14 - 2017-05-03
 - BREAKING: Bundler options now include `strategy` and `urlMapper`.  These

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.2",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "2.0.0-alpha.41",
+    "polymer-analyzer": "2.0.0-alpha.42",
     "source-map": "^0.5.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "nopt": "^3.0.1",
     "parse5": "^2.2.2",
     "path-posix": "^1.0.0",
-    "polymer-analyzer": "2.0.0-alpha.40",
+    "polymer-analyzer": "2.0.0-alpha.41",
     "source-map": "^0.5.6"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fixed case where an inlined import's `<link rel="lazy-import">` tags
   were being moved.
- Updated `polymer-analyzer` to latest version.
- [x] CHANGELOG.md has been updated
