### PR TITLE
Fixed issue with lazy-import hrefs being adjusted during inlining.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
-
+## Unreleased
+- Fixed issue where an inlined import's `<link rel="lazy-import">` href
+  was being adjusted, but should not be adjusted when governed by the
+  containing dom-module's assetpath.
 <!-- Add new, unreleased changes here. -->
+
 
 ## 2.0.0-pre.15 - 2017-05-08
 - Fixed case where an inlined import's `<link rel="lazy-import">` tags

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -363,7 +363,7 @@ function rewriteElementAttrsBaseUrl(
     rewriteUrlsInTemplates?: boolean) {
   const nodes = dom5.queryAll(
       ast,
-      matchers.urlAttrs,
+      matchers.elementsWithUrlAttrsToRewrite,
       undefined,
       rewriteUrlsInTemplates ? dom5.childNodesIncludeTemplate :
                                dom5.defaultChildNodes);

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -90,8 +90,8 @@ export const hiddenDiv: Matcher = predicates.AND(
 export const inHiddenDiv: Matcher = predicates.parentMatches(hiddenDiv);
 
 export const elementsWithUrlAttrsToRewrite: Matcher = predicates.AND(
-    predicates.OR.apply(
-        null, constants.URL_ATTR.map((attr) => predicates.hasAttr(attr))),
+    predicates.OR(
+        ...constants.URL_ATTR.map((attr) => predicates.hasAttr(attr))),
     predicates.NOT(predicates.AND(
         predicates.parentMatches(predicates.hasTagName('dom-module')),
         lazyHtmlImport)));

--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -20,12 +20,6 @@ import {predicates} from 'dom5';
 import * as parse5 from 'parse5';
 
 export interface Matcher { (node: parse5.ASTNode): boolean; }
-;
-
-export const urlAttrMatchers: (Matcher)[] =
-    constants.URL_ATTR.map((attr) => predicates.hasAttr(attr));
-
-export const urlAttrs: Matcher = predicates.OR.apply(null, urlAttrMatchers);
 
 export const jsMatcher: Matcher = predicates.AND(
     predicates.hasTagName('script'),
@@ -66,16 +60,6 @@ export const externalJavascript: Matcher =
     predicates.AND(predicates.hasAttr('src'), jsMatcher);
 export const inlineJavascript: Matcher =
     predicates.AND(predicates.NOT(predicates.hasAttr('src')), jsMatcher);
-export const htmlImport: Matcher = predicates.AND(
-    predicates.hasTagName('link'),
-    predicates.OR(
-        predicates.hasAttrValue('rel', 'import'),
-        predicates.hasAttrValue('rel', 'lazy-import')),
-    predicates.hasAttr('href'),
-    predicates.OR(
-        predicates.hasAttrValue('type', 'text/html'),
-        predicates.hasAttrValue('type', 'html'),
-        predicates.NOT(predicates.hasAttr('type'))));
 export const eagerHtmlImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
     predicates.hasAttrValue('rel', 'import'),
@@ -84,6 +68,16 @@ export const eagerHtmlImport: Matcher = predicates.AND(
         predicates.hasAttrValue('type', 'text/html'),
         predicates.hasAttrValue('type', 'html'),
         predicates.NOT(predicates.hasAttr('type'))));
+export const lazyHtmlImport: Matcher = predicates.AND(
+    predicates.hasTagName('link'),
+    predicates.hasAttrValue('rel', 'lazy-import'),
+    predicates.hasAttr('href'),
+    predicates.OR(
+        predicates.hasAttrValue('type', 'text/html'),
+        predicates.hasAttrValue('type', 'html'),
+        predicates.NOT(predicates.hasAttr('type'))));
+export const htmlImport: Matcher =
+    predicates.OR(eagerHtmlImport, lazyHtmlImport);
 export const stylesheetImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
     predicates.hasAttrValue('rel', 'import'),
@@ -94,6 +88,13 @@ export const hiddenDiv: Matcher = predicates.AND(
     predicates.hasAttr('hidden'),
     predicates.hasAttr('by-polymer-bundler'));
 export const inHiddenDiv: Matcher = predicates.parentMatches(hiddenDiv);
+
+export const elementsWithUrlAttrsToRewrite: Matcher = predicates.AND(
+    predicates.OR.apply(
+        null, constants.URL_ATTR.map((attr) => predicates.hasAttr(attr))),
+    predicates.NOT(predicates.AND(
+        predicates.parentMatches(predicates.hasTagName('dom-module')),
+        lazyHtmlImport)));
 
 /**
  * TODO(usergenic): From garlicnation's PR comment - "This matcher needs to deal

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -63,9 +63,12 @@ suite('Bundler', () => {
       const entrypoint = 'lazy-imports.html';
       const lazyImport1 = 'lazy-imports/lazy-import-1.html';
       const lazyImport2 = 'lazy-imports/lazy-import-2.html';
+      const lazyImport3 = 'lazy-imports/subfolder/lazy-import-3.html';
       const shared1 = 'lazy-imports/shared-eager-import-1.html';
       const shared2 = 'lazy-imports/shared-eager-import-2.html';
       const shared3 = 'lazy-imports/shared-eager-and-lazy-import-1.html';
+      const eager1 = 'lazy-imports/subfolder/eager-import-1.html';
+      const eager2 = 'lazy-imports/subfolder/eager-import-2.html';
       const deeply1 = 'lazy-imports/deeply-lazy-import-1.html';
       const deeply2 = 'lazy-imports/deeply-lazy-imports-eager-import-1.html';
       const analyzer =
@@ -73,7 +76,11 @@ suite('Bundler', () => {
       const expectedEntrypointsToDeps = new Map([
         [entrypoint, new Set([entrypoint, shared3])],
         [lazyImport1, new Set([lazyImport1, shared1, shared2])],
-        [lazyImport2, new Set([lazyImport2, shared1, shared2, shared3])],
+        [
+          lazyImport2,
+          new Set([lazyImport2, shared1, shared2, shared3, eager1, eager2])
+        ],
+        [lazyImport3, new Set([lazyImport3])],
         [shared3, new Set([shared3])],
         [deeply1, new Set([deeply1, deeply2])],
       ]);

--- a/test/html/imports/lazy-imports.html
+++ b/test/html/imports/lazy-imports.html
@@ -1,12 +1,17 @@
 <html>
 
 <head>
-    <link rel="import" href="lazy-imports/shared-eager-and-lazy-import-1.html">
-    <link rel="lazy-import" group="one" href="lazy-imports/lazy-import-1.html">
-    <link rel="lazy-import" group="two" href="lazy-imports/lazy-import-2.html">
+  <link rel="import" href="lazy-imports/shared-eager-and-lazy-import-1.html">
+  <link rel="lazy-import" group="one" href="lazy-imports/lazy-import-1.html">
 </head>
 
 <body>
+  <dom-module id="element-1">
+    <link rel="lazy-import" group="two" href="lazy-imports/lazy-import-2.html">
+    <script>
+      console.log('element-1');
+    </script>
+  </dom-module>
 </body>
 
 </html>

--- a/test/html/imports/lazy-imports/lazy-import-1.html
+++ b/test/html/imports/lazy-imports/lazy-import-1.html
@@ -1,5 +1,8 @@
 <link rel="import" href="shared-eager-import-1.html">
-<link rel="lazy-import" href="shared-eager-and-lazy-import-1.html">
-<div id="lazy-import-1">
+
+<dom-module id="lazy-imported-element-1">
+  <link rel="lazy-import" href="shared-eager-and-lazy-import-1.html">
+  <template id="lazy-import-1">
     I am lazy import 1
-</div>
+  </template>
+</dom-module>

--- a/test/html/imports/lazy-imports/lazy-import-2.html
+++ b/test/html/imports/lazy-imports/lazy-import-2.html
@@ -1,5 +1,6 @@
 <link rel="import" href="shared-eager-import-1.html">
 <link rel="import" href="shared-eager-and-lazy-import-1.html">
+<link rel="import" href="subfolder/eager-import-1.html">
 <div id="lazy-import-2">
   I am lazy import 2
 </div>

--- a/test/html/imports/lazy-imports/subfolder/eager-import-1.html
+++ b/test/html/imports/lazy-imports/subfolder/eager-import-1.html
@@ -1,0 +1,7 @@
+<dom-module id="eager-import-1">
+  <link rel="import" href="eager-import-2.html">
+  <link rel="lazy-import" href="lazy-import-3.html">
+  <script>
+    console.log('eager-import-1');
+  </script>
+</dom-module>

--- a/test/html/imports/lazy-imports/subfolder/eager-import-2.html
+++ b/test/html/imports/lazy-imports/subfolder/eager-import-2.html
@@ -1,0 +1,3 @@
+<div id="eager-import-2">
+  Eager eager
+</div>

--- a/test/html/imports/lazy-imports/subfolder/lazy-import-3.html
+++ b/test/html/imports/lazy-imports/subfolder/lazy-import-3.html
@@ -1,0 +1,3 @@
+<div id="lazy-import-3">
+  Lazy lazy lazy
+</div>


### PR DESCRIPTION
- Lazy import hrefs should not be adjusted, *when* they are governed by assetpath of a containing dom-module.
- Fixes #504 
- [x] CHANGELOG.md has been updated
