### PR TITLE
Updated the `bundle()` method to return a `BundleResult`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
-
+## Unreleased
+- BREAKING: Bundler's `bundle()` method now returns a `BundleResult`
+  instead of just a document collection. It does this to include a
+  copy of the provided manifest, where each bundle includes a record
+  of the sets of imports which were inlined during bundling.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.0-pre.16 - 2017-05-10

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -192,7 +192,8 @@ function documentCollectionToManifestJson(documents: DocumentCollection):
       }
     }
     const manifest = await bundler.generateManifest(entrypoints);
-    bundles = await bundler.bundle(manifest);
+    const result = await bundler.bundle(manifest);
+    bundles = result.documents;
   } catch (err) {
     console.log(err);
     return;

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -12,6 +12,8 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
+import * as clone from 'clone';
+
 import {UrlString} from './url-utils';
 
 /**
@@ -42,6 +44,11 @@ export class Bundle {
 
   // Set of all files included in the bundle.
   files: Set<UrlString>;
+
+  // These sets are updated as bundling occurs.
+  inlinedHtmlImports = new Set<UrlString>();
+  inlinedScripts = new Set<UrlString>();
+  inlinedStyles = new Set<UrlString>();
 
   constructor(entrypoints?: Set<UrlString>, files?: Set<UrlString>) {
     this.entrypoints = entrypoints || new Set<UrlString>();
@@ -83,6 +90,11 @@ export class BundleManifest {
         this._bundleUrlForFile.set(fileUrl, bundleUrl);
       }
     }
+  }
+
+  // Returns a clone of the manifest.
+  clone(): BundleManifest {
+    return clone(this);
   }
 
   // Convenience method to return a bundle for a constituent file url.
@@ -248,13 +260,22 @@ export function generateShellMergeStrategy(
  */
 export function mergeBundles(bundles: Bundle[]): Bundle {
   const newBundle = new Bundle();
-  for (const bundle of bundles) {
-    for (const url of bundle.entrypoints) {
-      newBundle.entrypoints.add(url);
-    }
-    for (const url of bundle.files) {
-      newBundle.files.add(url);
-    }
+  for (const {
+         entrypoints,
+         files,
+         inlinedHtmlImports,
+         inlinedScripts,
+         inlinedStyles,
+       } of bundles) {
+    newBundle.entrypoints =
+        new Set<UrlString>([...newBundle.entrypoints, ...entrypoints]);
+    newBundle.files = new Set<UrlString>([...newBundle.files, ...files]);
+    newBundle.inlinedHtmlImports = new Set<UrlString>(
+        [...newBundle.inlinedHtmlImports, ...inlinedHtmlImports]);
+    newBundle.inlinedScripts =
+        new Set<UrlString>([...newBundle.inlinedScripts, ...inlinedScripts]);
+    newBundle.inlinedStyles =
+        new Set<UrlString>([...newBundle.inlinedStyles, ...inlinedStyles]);
   }
   return newBundle;
 }

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -93,7 +93,7 @@ export class BundleManifest {
   }
 
   // Returns a clone of the manifest.
-  clone(): BundleManifest {
+  fork(): BundleManifest {
     return clone(this);
   }
 

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -122,7 +122,7 @@ export class Bundler {
    */
   async bundle(manifest: BundleManifest): Promise<BundleResult> {
     const documents: DocumentCollection = new Map<string, BundledDocument>();
-    manifest = manifest.clone();
+    manifest = manifest.fork();
 
     for (const bundleEntry of manifest.bundles) {
       const bundleUrl = bundleEntry[0];

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -120,19 +120,19 @@ export class Bundler {
    *
    * @param manifest - The manifest that describes the bundles to be produced.
    */
-  async bundle(manifest: BundleManifest): Promise<DocumentCollection> {
-    const bundledDocuments: DocumentCollection =
-        new Map<string, BundledDocument>();
+  async bundle(manifest: BundleManifest): Promise<BundleResult> {
+    const documents: DocumentCollection = new Map<string, BundledDocument>();
+    manifest = manifest.clone();
 
     for (const bundleEntry of manifest.bundles) {
       const bundleUrl = bundleEntry[0];
       const bundle = {url: bundleUrl, bundle: bundleEntry[1]};
       const bundledAst = await this._bundleDocument(bundle, manifest);
-      bundledDocuments.set(
+      documents.set(
           bundleUrl, {ast: bundledAst, files: Array.from(bundle.bundle.files)});
     }
 
-    return bundledDocuments;
+    return {manifest, documents};
   }
 
   /**
@@ -248,11 +248,11 @@ export class Bundler {
     await this._inlineHtmlImports(document, ast, docBundle, bundleManifest);
 
     if (this.enableScriptInlining) {
-      await this._inlineScripts(document, ast);
+      await this._inlineScripts(document, ast, docBundle);
     }
     if (this.enableCssInlining) {
-      await this._inlineStylesheetLinks(document, ast);
-      await this._inlineStylesheetImports(document, ast);
+      await this._inlineStylesheetLinks(document, ast, docBundle);
+      await this._inlineStylesheetImports(document, ast, docBundle);
     }
 
     if (this.stripComments) {
@@ -348,11 +348,14 @@ export class Bundler {
    * Replace all external javascript tags (`<script src="...">`)
    * with `<script>` tags containing the file contents inlined.
    */
-  private async _inlineScripts(document: Document, ast: ASTNode) {
+  private async _inlineScripts(
+      document: Document,
+      ast: ASTNode,
+      bundle: AssignedBundle): Promise<void> {
     const scriptImports = dom5.queryAll(ast, matchers.externalJavascript);
     for (const externalScript of scriptImports) {
       await importUtils.inlineScript(
-          this.analyzer, document, externalScript, this.sourcemaps);
+          this.analyzer, document, externalScript, bundle, this.sourcemaps);
     }
   }
 
@@ -361,11 +364,14 @@ export class Bundler {
    * with `<style>` tags containing the file contents, with internal URLs
    * relatively transposed as necessary.
    */
-  private async _inlineStylesheetImports(document: Document, ast: ASTNode) {
+  private async _inlineStylesheetImports(
+      document: Document,
+      ast: ASTNode,
+      bundle: AssignedBundle) {
     const cssImports = dom5.queryAll(ast, matchers.stylesheetImport);
     for (const cssLink of cssImports) {
-      const style =
-          await importUtils.inlineStylesheet(this.analyzer, document, cssLink);
+      const style = await importUtils.inlineStylesheet(
+          this.analyzer, document, cssLink, bundle);
       if (style) {
         this._moveDomModuleStyleIntoTemplate(style);
       }
@@ -377,10 +383,14 @@ export class Bundler {
    * tags with `<style>` tags containing file contents, with internal URLs
    * relatively transposed as necessary.
    */
-  private async _inlineStylesheetLinks(document: Document, ast: ASTNode) {
+  private async _inlineStylesheetLinks(
+      document: Document,
+      ast: ASTNode,
+      bundle: AssignedBundle) {
     const cssLinks = dom5.queryAll(ast, matchers.externalStyle);
     for (const cssLink of cssLinks) {
-      await importUtils.inlineStylesheet(this.analyzer, document, cssLink);
+      await importUtils.inlineStylesheet(
+          this.analyzer, document, cssLink, bundle);
     }
   }
 

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -150,6 +150,9 @@ export async function inlineHtmlImport(
   astUtils.insertAllBefore(linkTag.parentNode!, linkTag, importAst.childNodes!);
   astUtils.removeElementAndNewline(linkTag);
 
+  // Record that the inlining took place.
+  docBundle.bundle.inlinedHtmlImports.add(resolvedImportUrl);
+
   // Recursively process the nested imports.
   for (const nestedImport of nestedImports) {
     await inlineHtmlImport(
@@ -172,6 +175,7 @@ export async function inlineScript(
     analyzer: Analyzer,
     document: Document,
     scriptTag: ASTNode,
+    docBundle: AssignedBundle,
     enableSourcemaps: boolean) {
   const rawImportUrl = dom5.getAttribute(scriptTag, 'src')!;
   const importUrl = urlLib.resolve(document.url, rawImportUrl);
@@ -199,6 +203,10 @@ export async function inlineScript(
 
   dom5.removeAttribute(scriptTag, 'src');
   dom5.setTextContent(scriptTag, encodeString(scriptContent, true));
+
+  // Record that the inlining took place.
+  docBundle.bundle.inlinedScripts.add(resolvedImportUrl);
+
   return scriptContent;
 }
 
@@ -207,7 +215,10 @@ export async function inlineScript(
  * into a style tag and removes the link tag.
  */
 export async function inlineStylesheet(
-    analyzer: Analyzer, document: Document, cssLink: ASTNode) {
+    analyzer: Analyzer,
+    document: Document,
+    cssLink: ASTNode,
+    docBundle: AssignedBundle) {
   const stylesheetUrl = dom5.getAttribute(cssLink, 'href')!;
   const importUrl = urlLib.resolve(document.url, stylesheetUrl);
   if (!analyzer.canResolveUrl(importUrl)) {
@@ -238,6 +249,10 @@ export async function inlineStylesheet(
 
   dom5.replace(cssLink, styleNode);
   dom5.setTextContent(styleNode, resolvedStylesheetContent);
+
+  // Record that the inlining took place.
+  docBundle.bundle.inlinedStyles.add(resolvedImportUrl);
+
   return styleNode;
 }
 

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -60,10 +60,9 @@ suite('Bundler', () => {
 
     test('URLs for inlined HTML imports are recorded in Bundle', async () => {
       await bundle(inputPath);
-      assert.sameMembers(
+      assert.deepEqual(
           [...documentBundle.inlinedHtmlImports],
-          ['imports/simple-import.html'],
-          [...documentBundle.inlinedHtmlImports].join(', '));
+          ['imports/simple-import.html']);
     });
 
     test('imports removed', async () => {
@@ -526,10 +525,8 @@ suite('Bundler', () => {
 
     test('URLs for inlined scripts are recorded in Bundle', async () => {
       await bundle('test/html/external.html');
-      assert.sameMembers(
-          [...documentBundle.inlinedScripts],
-          ['external/external.js'],
-          [...documentBundle.inlinedScripts].join(', '));
+      assert.deepEqual(
+          [...documentBundle.inlinedScripts], ['external/external.js']);
     });
 
     test('External script tags are replaced with inline scripts', async () => {
@@ -547,10 +544,9 @@ suite('Bundler', () => {
       assert.equal(
           dom5.getAttribute(scripts[0], 'src'),
           'https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js');
-      assert.sameMembers(
-          [...documentBundle.inlinedScripts],
-          ['external/external.js', 'imports/external.js'],
-          [...documentBundle.inlinedScripts].join(', '));
+      assert.deepEqual(
+          [...documentBundle.inlinedScripts].sort(),
+          ['external/external.js', 'imports/external.js']);
     });
 
     test.skip('Absolute paths are correct for excluded links', async () => {
@@ -601,10 +597,9 @@ suite('Bundler', () => {
 
     test('URLs for inlined styles are recorded in Bundle', async () => {
       await bundle(inputPath);
-      assert.sameMembers(
-          [...documentBundle.inlinedStyles],
-          ['imports/regular-style.css', 'imports/simple-style.css'],
-          [...documentBundle.inlinedStyles].join(', '));
+      assert.deepEqual(
+          [...documentBundle.inlinedStyles].sort(),
+          ['imports/regular-style.css', 'imports/simple-style.css']);
     });
 
     test('External links are replaced with inlined styles', async () => {

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -20,9 +20,8 @@ import * as parse5 from 'parse5';
 import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
 
 import {generateSharedDepsMergeStrategy, generateShellMergeStrategy} from '../bundle-manifest';
-import {Bundler} from '../bundler';
+import {Bundler, BundleResult} from '../bundler';
 import {Options as BundlerOptions} from '../bundler';
-import {DocumentCollection} from '../document-collection';
 
 chai.config.showDiff = true;
 
@@ -42,7 +41,7 @@ suite('Bundler', () => {
   const entrypoint2 = 'test/html/shards/shop_style_project/entrypoint2.html';
 
   async function bundleMultiple(inputPath: string[], opts?: BundlerOptions):
-      Promise<DocumentCollection> {
+      Promise<BundleResult> {
         const bundlerOpts = opts || {};
         if (!bundlerOpts.analyzer) {
           bundlerOpts.analyzer = new Analyzer({urlLoader: new FSUrlLoader()});
@@ -68,17 +67,17 @@ suite('Bundler', () => {
 
   suite('Sharded builds', () => {
     test('with 3 entrypoints, all deps are in their places', async () => {
-      const docs = await bundleMultiple(
+      const {documents} = await bundleMultiple(
           [common, entrypoint1, entrypoint2],
           {strategy: generateSharedDepsMergeStrategy(2)});
-      assert.equal(docs.size, 4);
-      const commonDoc: parse5.ASTNode = docs.get(common)!.ast;
+      assert.equal(documents.size, 4);
+      const commonDoc: parse5.ASTNode = documents.get(common)!.ast;
       assert.isDefined(commonDoc);
-      const entrypoint1Doc = docs.get(entrypoint1)!.ast;
+      const entrypoint1Doc = documents.get(entrypoint1)!.ast;
       assert.isDefined(entrypoint1Doc);
-      const entrypoint2Doc = docs.get(entrypoint2)!.ast;
+      const entrypoint2Doc = documents.get(entrypoint2)!.ast;
       assert.isDefined(entrypoint2Doc);
-      const sharedDoc = docs.get('shared_bundle_1.html')!.ast;
+      const sharedDoc = documents.get('shared_bundle_1.html')!.ast;
       assert.isDefined(sharedDoc);
       const commonModule = domModulePredicate('common-module');
       const elOne = domModulePredicate('el-one');
@@ -97,15 +96,15 @@ suite('Bundler', () => {
     });
 
     test('with 2 entrypoints and shell, all deps in their places', async () => {
-      const docs = await bundleMultiple(
+      const {documents} = await bundleMultiple(
           [shell, entrypoint1, entrypoint2],
           {strategy: generateShellMergeStrategy(shell, 2)});
-      assert.equal(docs.size, 3);
-      const shellDoc: parse5.ASTNode = docs.get(shell)!.ast;
+      assert.equal(documents.size, 3);
+      const shellDoc: parse5.ASTNode = documents.get(shell)!.ast;
       assert.isDefined(shellDoc);
-      const entrypoint1Doc = docs.get(entrypoint1)!.ast;
+      const entrypoint1Doc = documents.get(entrypoint1)!.ast;
       assert.isDefined(entrypoint1Doc);
-      const entrypoint2Doc = docs.get(entrypoint2)!.ast;
+      const entrypoint2Doc = documents.get(entrypoint2)!.ast;
       assert.isDefined(entrypoint2Doc);
       const shellDiv = dom5.predicates.hasAttrValue('id', 'shell');
       const commonModule = domModulePredicate('common-module');

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -44,7 +44,7 @@ suite('Bundler', () => {
         }
         bundler = new Bundler(bundlerOpts);
         const manifest = await bundler.generateManifest([inputPath]);
-        const documents = await bundler.bundle(manifest);
+        const {documents} = await bundler.bundle(manifest);
         return documents.get(inputPath)!.ast;
       }
 


### PR DESCRIPTION
This PR is an important prerequisite that will make it possible for `polymer-build` to filter out inlined files from its `BuildBundler` transform stream.

 - This result contains a clone of the provided manifest, where
   each Bundle contains a record of the imports it inlined.
 - [x] CHANGELOG.md has been updated
