### PR TITLE
Fix URL rewriting condition where mixed absolute and relative base hrefs are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Fixed a bug with url-rewriting in cases where base urls provided
+  has mix of relative and absolute pathnames.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.0-pre.18 - 2017-05-15

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -58,25 +58,47 @@ suite('URL Utils', () => {
 
   suite('Rewrite imported relative paths', () => {
 
-    const importDocPath = '/foo/bar/my-element/index.html';
-    const mainDocPath = '/foo/bar/index.html';
-
-    function testRewrite(val: string, expected: string, msg?: string) {
-      const actual =
-          urlUtils.rewriteHrefBaseUrl(val, importDocPath, mainDocPath);
+    function testRewrite(
+        href: string,
+        oldBaseUrl: string,
+        newBaseUrl: string,
+        expected: string,
+        msg?: string) {
+      const actual = urlUtils.rewriteHrefBaseUrl(href, oldBaseUrl, newBaseUrl);
       assert.equal(actual, expected, msg);
     }
 
-    test('Rewrite Paths', () => {
-      testRewrite('biz.jpg', 'my-element/biz.jpg', 'local');
-      testRewrite('http://foo/biz.jpg', 'http://foo/biz.jpg', 'remote');
-      testRewrite('#foo', '#foo', 'hash');
+    test('Some URL forms are not rewritten', () => {
+      const importBase = '/could/be/anything/local/import.html';
+      const mainBase = '/foo/bar/index.html';
+      testRewrite('#foo', importBase, mainBase, '#foo', 'just a hash');
+      testRewrite(
+          'http://foo/biz.jpg',
+          importBase,
+          mainBase,
+          'http://foo/biz.jpg',
+          'remote urls');
+      testRewrite(
+          '/a/b/c/', importBase, mainBase, '/a/b/c/', 'local absolute href');
     });
 
-    test('Rewrite Paths with absolute paths', () => {
-      testRewrite('biz.jpg', 'my-element/biz.jpg', 'local');
-      testRewrite('http://foo/biz.jpg', 'http://foo/biz.jpg', 'local');
-      testRewrite('#foo', '#foo', 'hash');
+    test('Rewrite Paths when base url pathnames are absolute paths', () => {
+      const importBase = '/foo/bar/my-element/index.html';
+      const mainBase = '/foo/bar/index.html';
+      testRewrite(
+          'biz.jpg', importBase, mainBase, 'my-element/biz.jpg', 'relative');
+      testRewrite('/biz.jpg', importBase, mainBase, '/biz.jpg', 'absolute');
+    });
+
+    test('Rewrite paths when base url pathnames have no leading slash', () => {
+      testRewrite(
+          '/foo.html', 'bar.html', 'index.html', '/foo.html', 'href has ^/');
+      testRewrite(
+          'foo.html', '/bar.html', 'index.html', 'foo.html', 'only new has ^/');
+      testRewrite(
+          'foo.html', 'bar.html', '/index.html', 'foo.html', 'only old has ^/');
+      testRewrite(
+          'foo.html', 'bar.html', 'index.html', 'foo.html', 'neither has ^/');
     });
   });
 

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -104,9 +104,14 @@ export function rewriteHrefBaseUrl(
   if (parsedFrom.protocol === parsedTo.protocol &&
       parsedFrom.host === parsedTo.host) {
     const pathname = path.posix.relative(
-        path.posix.dirname(parsedFrom.pathname || ''), parsedTo.pathname || '');
+        makeAbsolutePath(path.posix.dirname(parsedFrom.pathname || '')),
+        makeAbsolutePath(parsedTo.pathname || ''));
     return url.format(
         {pathname: pathname, search: parsedTo.search, hash: parsedTo.hash});
   }
   return absUrl;
+}
+
+function makeAbsolutePath(path: string): string {
+  return path.startsWith('/') ? path : '/' + path;
 }


### PR DESCRIPTION
This guards against a subtle bug that occurs in clients of the bundler href rewriting function which may provide hrefs that have pathnames without leading slashes.  The result of this was that rewritten urls would look like '../../../../target.html' where the number of '../' items would be driven by whatever the *local filesystem* path resolution concluded the path referenced.

This manifests in polymer-cli attempting to bundle files with a base tags containing absolute hrefs and generating bogus hrefs.
