### PR TITLE
Do not include the `by-polymer-bundler` hidden div in bundled files if it is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Don't include the `by-polymer-bundler` hidden div in bundled files
+  if it is empty.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.0 - 2017-05-18

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -489,7 +489,7 @@ export class Bundler {
   }
 
   /**
-   * Removed all empty hidden container divs from the AST.
+   * Removes all empty hidden container divs from the AST.
    */
   private _removeEmptyHiddenDivs(ast: ASTNode) {
     for (const div of dom5.queryAll(ast, matchers.hiddenDiv)) {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -13,6 +13,7 @@
  */
 import * as clone from 'clone';
 import * as dom5 from 'dom5';
+import * as parse5 from 'parse5';
 import {ASTNode, serialize, treeAdapters} from 'parse5';
 import * as path from 'path';
 import {Analyzer, Document, FSUrlLoader, InMemoryOverlayUrlLoader} from 'polymer-analyzer';
@@ -259,6 +260,8 @@ export class Bundler {
       astUtils.stripComments(ast);
     }
 
+    this._removeEmptyHiddenDivs(ast);
+
     if (this.sourcemaps) {
       return updateSourcemapLocations(document, ast);
     } else {
@@ -483,5 +486,16 @@ export class Bundler {
     this._moveUnhiddenHtmlImportsIntoHiddenDiv(ast);
     dom5.removeFakeRootElements(ast);
     return this._analyzeContents(document.url, serialize(ast));
+  }
+
+  /**
+   * Removed all empty hidden container divs from the AST.
+   */
+  private _removeEmptyHiddenDivs(ast: ASTNode) {
+    for (const div of dom5.queryAll(ast, matchers.hiddenDiv)) {
+      if (parse5.serialize(div).trim() === '') {
+        dom5.remove(div);
+      }
+    }
   }
 }

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -760,6 +760,12 @@ suite('Bundler', () => {
       ]);
     });
 
+    test('Bundler should not emit empty hidden divs', async () => {
+      const doc = await bundle('test/html/import-empty.html');
+      assert(doc);
+      assert.isNull(dom5.query(doc, matchers.hiddenDiv));
+    });
+
     test('Entrypoint body content should not be wrapped', async () => {
       const doc = await bundle('test/html/default.html');
       assert(doc);

--- a/test/html/import-empty.html
+++ b/test/html/import-empty.html
@@ -1,0 +1,3 @@
+<link rel="import" href="empty-import/empty.html">
+
+<h1>Nothing special</h1>


### PR DESCRIPTION
 - This is seemingly innocuous, but it helps simplify integration tests up in the CLI.
 - Also fixes https://github.com/Polymer/polymer-bundler/issues/507
 - [x] CHANGELOG.md has been updated
