### PR TITLE
Add the sourcesContent field to generated source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
 <!-- Add new, unreleased changes here. -->
+- Add `sourcesContent` to generated source maps.
 
 ## 2.0.1 - 2017-05-19
 - Don't include the `by-polymer-bundler` hidden div in bundled files

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -72,6 +72,7 @@ function createJsIdentitySourcemap(
     generator.addMapping(mapping);
   });
 
+  generator.setSourceContent(sourceUrl, sourceContent);
   return generator.toJSON();
 }
 
@@ -96,6 +97,10 @@ function offsetSourceMap(
     }
 
     generator.addMapping(newMapping);
+  });
+
+  sourcemap.sources.forEach(source => {
+    generator.setSourceContent(source, consumer.sourceContentFor(source));
   });
 
   return generator.toJSON();

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -46,6 +46,7 @@ function rawSourceMapToBase64String(sourcemap: RawSourceMap) {
 export function createJsIdentitySourcemap(
     sourceUrl: string,
     sourceContent: string,
+    originalFileContent: string,
     lineOffset: number,
     firstLineCharOffset: number) {
   const generator = new SourceMapGenerator();
@@ -72,7 +73,7 @@ export function createJsIdentitySourcemap(
     generator.addMapping(mapping);
   });
 
-  generator.setSourceContent(sourceUrl, sourceContent);
+  generator.setSourceContent(sourceUrl, originalFileContent);
   return generator.toJSON();
 }
 
@@ -161,12 +162,14 @@ export async function addOrUpdateSourcemapComment(
     sourceContent = sourceContent.replace(sourceMappingUrlExpr, '');
   }
 
+  const originalFileContent = await analyzer.load(sourceUrl);
   let hasExisting = true;
   if (sourcemap === null) {
     hasExisting = false;
     sourcemap = createJsIdentitySourcemap(
         sourceUrl,
         sourceContent,
+        originalFileContent,
         originalLineOffset,
         originalFirstLineCharOffset);
   } else {

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -43,7 +43,7 @@ function rawSourceMapToBase64String(sourcemap: RawSourceMap) {
  * Creates an identity source map from JS script content. Can offset original
  * line/column data for inline script elements.
  */
-export function createJsIdentitySourcemap(
+function createJsIdentitySourcemap(
     sourceUrl: string,
     sourceContent: string,
     originalFileContent: string,
@@ -77,7 +77,7 @@ export function createJsIdentitySourcemap(
   return generator.toJSON();
 }
 
-export function offsetSourceMap(
+function offsetSourceMap(
     sourcemap: RawSourceMap, lineOffset: number, firstLineCharOffset: number) {
   const consumer = new SourceMapConsumer(sourcemap);
   const generator = new SourceMapGenerator();

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -43,7 +43,7 @@ function rawSourceMapToBase64String(sourcemap: RawSourceMap) {
  * Creates an identity source map from JS script content. Can offset original
  * line/column data for inline script elements.
  */
-function createJsIdentitySourcemap(
+export function createJsIdentitySourcemap(
     sourceUrl: string,
     sourceContent: string,
     lineOffset: number,
@@ -76,7 +76,7 @@ function createJsIdentitySourcemap(
   return generator.toJSON();
 }
 
-function offsetSourceMap(
+export function offsetSourceMap(
     sourcemap: RawSourceMap, lineOffset: number, firstLineCharOffset: number) {
   const consumer = new SourceMapConsumer(sourcemap);
   const generator = new SourceMapGenerator();

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -23,7 +23,10 @@ import {MappingItem, RawSourceMap, SourceMapConsumer} from 'source-map';
 
 import {Bundler} from '../bundler';
 import {Options as BundlerOptions} from '../bundler';
-import {getExistingSourcemap} from '../source-map';
+import {
+  getExistingSourcemap,
+  createJsIdentitySourcemap,
+  offsetSourceMap} from '../source-map';
 
 chai.config.showDiff = true;
 
@@ -161,6 +164,26 @@ suite('Bundler', () => {
         assert(sourcemap, 'scripts found');
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
+    });
+
+    test('sourcesContent is generated for new sourcemaps', () => {
+      const sourcemap = createJsIdentitySourcemap(
+          'foo', 'console.log(\'Hello world\');', 0, 0);
+      assert(sourcemap.sourcesContent, 'sourcesContent found');
+      assert.lengthOf(sourcemap.sourcesContent!, 1, 'sourcesContent length');
+      assert.equal(sourcemap.sourcesContent![0], 'console.log(\'Hello world\');',
+        'sourcesContent value');
+    });
+
+    test('sourcesContent is preserved for existing sourcemaps', () => {
+      const sourcemap = createJsIdentitySourcemap(
+        'foo', 'console.log(\'Hello world\');', 0, 0);
+      const offsetSourcemap = offsetSourceMap(
+        sourcemap, 1, 0);
+      assert(offsetSourcemap.sourcesContent, 'sourcesContent found');
+      assert.lengthOf(offsetSourcemap.sourcesContent!, 1, 'sourcesContent length');
+      assert.equal(offsetSourcemap.sourcesContent![0], 'console.log(\'Hello world\');',
+        'sourcesContent value');
     });
   });
 });

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -24,10 +24,7 @@ import {MappingItem, RawSourceMap, SourceMapConsumer} from 'source-map';
 
 import {Bundler} from '../bundler';
 import {Options as BundlerOptions} from '../bundler';
-import {
-  getExistingSourcemap,
-  createJsIdentitySourcemap,
-  offsetSourceMap} from '../source-map';
+import {getExistingSourcemap} from '../source-map';
 
 chai.config.showDiff = true;
 
@@ -101,17 +98,15 @@ suite('Bundler', () => {
       assert.equal(inlineScripts.length, 3);
 
       for (let i = 0; i < inlineScripts.length; i++) {
-        if (i === 5) {
-          continue;
-        }
-
         const sourcemap = await getExistingSourcemap(
             analyzer, 'inline.html', dom5.getTextContent(inlineScripts[i]));
 
         assert(sourcemap, 'scripts found');
         sourcemap!.sources.forEach((source, index) => {
-          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
-          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          if (sourcemap && sourcemap.sourcesContent && sourcemap.sourcesContent[index]) {
+            const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+            assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          }
         });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
@@ -132,8 +127,10 @@ suite('Bundler', () => {
 
         assert(sourcemap, 'scripts found');
         sourcemap!.sources.forEach((source, index) => {
-          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
-          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          if (sourcemap && sourcemap.sourcesContent && sourcemap.sourcesContent[index]) {
+            const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+            assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          }
         });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
@@ -154,8 +151,10 @@ suite('Bundler', () => {
 
         assert(sourcemap, 'scripts found');
         sourcemap!.sources.forEach((source, index) => {
-          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
-          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          if (sourcemap && sourcemap.sourcesContent && sourcemap.sourcesContent[index]) {
+            const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+            assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          }
         });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
@@ -176,31 +175,13 @@ suite('Bundler', () => {
 
         assert(sourcemap, 'scripts found');
         sourcemap!.sources.forEach((source, index) => {
-          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
-          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          if (sourcemap && sourcemap.sourcesContent && sourcemap.sourcesContent[index]) {
+            const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+            assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+          }
         });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
-    });
-
-    test('sourcesContent is generated for new sourcemaps', () => {
-      const sourcemap = createJsIdentitySourcemap(
-          'foo', 'console.log(\'Hello world\');', 0, 0);
-      assert(sourcemap.sourcesContent, 'sourcesContent found');
-      assert.lengthOf(sourcemap.sourcesContent!, 1, 'sourcesContent length');
-      assert.equal(sourcemap.sourcesContent![0], 'console.log(\'Hello world\');',
-        'sourcesContent value');
-    });
-
-    test('sourcesContent is preserved for existing sourcemaps', () => {
-      const sourcemap = createJsIdentitySourcemap(
-        'foo', 'console.log(\'Hello world\');', 0, 0);
-      const offsetSourcemap = offsetSourceMap(
-        sourcemap, 1, 0);
-      assert(offsetSourcemap.sourcesContent, 'sourcesContent found');
-      assert.lengthOf(offsetSourcemap.sourcesContent!, 1, 'sourcesContent length');
-      assert.equal(offsetSourcemap.sourcesContent![0], 'console.log(\'Hello world\');',
-        'sourcesContent value');
     });
   });
 });

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -18,6 +18,7 @@ import * as chai from 'chai';
 import * as dom5 from 'dom5';
 import * as parse5 from 'parse5';
 import * as path from 'path';
+import * as fs from 'fs';
 import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
 import {MappingItem, RawSourceMap, SourceMapConsumer} from 'source-map';
 
@@ -108,6 +109,10 @@ suite('Bundler', () => {
             analyzer, 'inline.html', dom5.getTextContent(inlineScripts[i]));
 
         assert(sourcemap, 'scripts found');
+        sourcemap!.sources.forEach((source, index) => {
+          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+        });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
     });
@@ -126,6 +131,10 @@ suite('Bundler', () => {
             analyzer, 'external.html', dom5.getTextContent(inlineScripts[i]));
 
         assert(sourcemap, 'scripts found');
+        sourcemap!.sources.forEach((source, index) => {
+          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+        });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
     });
@@ -144,6 +153,10 @@ suite('Bundler', () => {
             analyzer, 'combined.html', dom5.getTextContent(inlineScripts[i]));
 
         assert(sourcemap, 'scripts found');
+        sourcemap!.sources.forEach((source, index) => {
+          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+        });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
     });
@@ -162,6 +175,10 @@ suite('Bundler', () => {
             analyzer, 'invalid.html', dom5.getTextContent(inlineScripts[i]));
 
         assert(sourcemap, 'scripts found');
+        sourcemap!.sources.forEach((source, index) => {
+          const originalFileContent = fs.readFileSync(path.join(basePath, source), 'utf-8');
+          assert.equal(sourcemap!.sourcesContent![index], originalFileContent, 'contents match');
+        });
         await testMapping(sourcemap!, compiledHtml, 'console');
       }
     });


### PR DESCRIPTION
Hello! :wave:

When working with the source maps generated by the `polymer-bundler`, I realized that although they gave me accurate stack traces, clicking on those traces would bring up a blank source in DevTools. After a bit of research, I leanred that this was because the source maps generated by `polymer-bundler` lacked a `sourcesContent` field, which is what DevTools uses to actually render the original source.

I am new to the science behind source maps (and to TypeScript!), so please forgive me if I've made some naive mistakes here.

I also have not yet added tests for this change in functionality, because I couldn't quite figure out how. Again, pardon my lack of experience.

If this is a desired change, then I'd be happy to put some more work into writing tests that cover this change.

Thanks! 🎉 

 - [x] CHANGELOG.md has been updated
