### PR TITLE
Change hasAttrValue('rel', ...) to hasSpaceSeparatedAttrValue('rel', …)

### DIFF
--- a/src/matchers.ts
+++ b/src/matchers.ts
@@ -30,11 +30,11 @@ export const jsMatcher: Matcher = predicates.AND(
 
 export const externalStyle: Matcher = predicates.AND(
     predicates.hasTagName('link'),
-    predicates.hasAttrValue('rel', 'stylesheet'));
+    predicates.hasSpaceSeparatedAttrValue('rel', 'stylesheet'));
 // polymer specific external stylesheet
 export const polymerExternalStyle: Matcher = predicates.AND(
     predicates.hasTagName('link'),
-    predicates.hasAttrValue('rel', 'import'),
+    predicates.hasSpaceSeparatedAttrValue('rel', 'import'),
     predicates.hasAttrValue('type', 'css'));
 
 export const styleMatcher: Matcher = predicates.AND(
@@ -62,7 +62,7 @@ export const inlineJavascript: Matcher =
     predicates.AND(predicates.NOT(predicates.hasAttr('src')), jsMatcher);
 export const eagerHtmlImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
-    predicates.hasAttrValue('rel', 'import'),
+    predicates.hasSpaceSeparatedAttrValue('rel', 'import'),
     predicates.hasAttr('href'),
     predicates.OR(
         predicates.hasAttrValue('type', 'text/html'),
@@ -70,7 +70,7 @@ export const eagerHtmlImport: Matcher = predicates.AND(
         predicates.NOT(predicates.hasAttr('type'))));
 export const lazyHtmlImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
-    predicates.hasAttrValue('rel', 'lazy-import'),
+    predicates.hasSpaceSeparatedAttrValue('rel', 'lazy-import'),
     predicates.hasAttr('href'),
     predicates.OR(
         predicates.hasAttrValue('type', 'text/html'),
@@ -80,7 +80,7 @@ export const htmlImport: Matcher =
     predicates.OR(eagerHtmlImport, lazyHtmlImport);
 export const stylesheetImport: Matcher = predicates.AND(
     predicates.hasTagName('link'),
-    predicates.hasAttrValue('rel', 'import'),
+    predicates.hasSpaceSeparatedAttrValue('rel', 'import'),
     predicates.hasAttr('href'),
     predicates.hasAttrValue('type', 'css'));
 export const hiddenDiv: Matcher = predicates.AND(

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -68,7 +68,7 @@ suite('Bundler', () => {
     test('imports removed', async () => {
       const imports = preds.AND(
           preds.hasTagName('link'),
-          preds.hasAttrValue('rel', 'import'),
+          preds.hasSpaceSeparatedAttrValue('rel', 'import'),
           preds.hasAttr('href'),
           preds.NOT(preds.hasAttrValue('type', 'css')));
       assert.equal(dom5.queryAll(await bundle(inputPath), imports).length, 0);
@@ -147,7 +147,7 @@ suite('Bundler', () => {
               document.ast!,
               preds.AND(
                   preds.hasTagName('link'),
-                  preds.hasAttrValue('rel', 'import')))!;
+                  preds.hasSpaceSeparatedAttrValue('rel', 'import')))!;
           assert(linkTag);
           assert.equal(
               dom5.getAttribute(linkTag, 'href'), '../../shared_bundle_1.html');
@@ -218,7 +218,7 @@ suite('Bundler', () => {
         preds.AND(
             preds.parentMatches(preds.hasTagName('dom-module')),
             preds.hasTagName('link'),
-            preds.hasAttrValue('rel', 'lazy-import')));
+            preds.hasSpaceSeparatedAttrValue('rel', 'lazy-import')));
     assert.equal(sharedLazyImports.length, 1);
     assert.equal(dom5.getAttribute(sharedLazyImports[0]!, 'group'), 'deeply');
   });
@@ -323,7 +323,8 @@ suite('Bundler', () => {
 
   test('Imports in <body> are handled correctly', async () => {
     const importMatcher = preds.AND(
-        preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
+        preds.hasTagName('link'),
+        preds.hasSpaceSeparatedAttrValue('rel', 'import'));
 
     const bodyContainerMatcher = preds.AND(
         preds.hasTagName('div'),
@@ -446,7 +447,7 @@ suite('Bundler', () => {
 
     const excluded = preds.AND(
         preds.hasTagName('link'),
-        preds.hasAttrValue('rel', 'import'),
+        preds.hasSpaceSeparatedAttrValue('rel', 'import'),
         preds.hasAttrValue('href', 'imports/simple-import.html'));
 
     const excludes = ['imports/simple-import.html'];
@@ -506,7 +507,8 @@ suite('Bundler', () => {
 
     test('Folder can be excluded', async () => {
       const linkMatcher = preds.AND(
-          preds.hasTagName('link'), preds.hasAttrValue('rel', 'import'));
+          preds.hasTagName('link'),
+          preds.hasSpaceSeparatedAttrValue('rel', 'import'));
       const options = {excludes: ['imports/']};
       const doc = await bundle('test/html/default.html', options);
       const links = dom5.queryAll(doc, linkMatcher);
@@ -779,7 +781,7 @@ suite('Bundler', () => {
       const doc = await bundle('test/html/inside-template.html');
       const importMatcher = preds.AND(
           preds.hasTagName('link'),
-          preds.hasAttrValue('rel', 'import'),
+          preds.hasSpaceSeparatedAttrValue('rel', 'import'),
           preds.hasAttr('href'));
       const externalScriptMatcher = preds.AND(
           preds.hasTagName('script'),


### PR DESCRIPTION
The 'rel' attribute contains/supports/specifies its contents as space-separated values.  Modified the matchers to use the space-separated version to better support the spec. 