### PR TITLE
Fix issue with ordering of html imports injected by shell strategy.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- When injecting html imports into documents for inlining, bundler now tries
+  to put them ahead of imports which will depend on them instead of just
+  appending to end of document. This is especially important in shell strategy
+  apps with other shared bundles or when shell eagerly imports fragments.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.1 - 2017-05-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- When injecting html imports into documents for inlining, bundler now tries
-  to put them ahead of imports which will depend on them instead of just
-  appending to end of document. This is especially important in shell strategy
-  apps with other shared bundles or when shell eagerly imports fragments.
+- In cases such as the shell merge strategy, imports which are not originally
+  part of the shell are now inserted before other imports which are dependent
+  on them.  Fixes https://github.com/Polymer/polymer-bundler/issues/517.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.1 - 2017-05-19

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -114,6 +114,28 @@ export function parse(html: string, options: ParserOptions): ASTNode {
 }
 
 /**
+ * Returns true if the nodes are given in order as they appear in the source
+ * code.
+ */
+export function inOrder(left: ASTNode, right: ASTNode): boolean {
+  const l = left.__location, r = right.__location;
+  return l && r && l['line'] && r['line'] &&
+      (l['line'] < r['line'] ||
+       (l['line'] === r['line'] && l['col'] < r['col']));
+}
+
+/**
+ * Returns true if both nodes have the same line and column according to their
+ * location info.
+ */
+export function sameNode(node1: ASTNode, node2: ASTNode): boolean {
+  const l1 = node1.__location, l2 = node2.__location;
+  return !!(
+      l1 && l2 && l1['line'] && l1['col'] && l1['line'] === l2['line'] &&
+      l1['col'] === l2['col']);
+}
+
+/**
  * Return all sibling nodes following node.
  */
 export function siblingsAfter(node: ASTNode): ASTNode[] {

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -116,6 +116,8 @@ export function parse(html: string, options: ParserOptions): ASTNode {
 /**
  * Returns true if the nodes are given in order as they appear in the source
  * code.
+ * TODO(usergenic): Port this to `dom5` and do it with typings for location info
+ * instead of all of these string-based lookups.
  */
 export function inOrder(left: ASTNode, right: ASTNode): boolean {
   const l = left.__location, r = right.__location;
@@ -127,6 +129,8 @@ export function inOrder(left: ASTNode, right: ASTNode): boolean {
 /**
  * Returns true if both nodes have the same line and column according to their
  * location info.
+ * TODO(usergenic): Port this to `dom5` and do it with typings for location info
+ * instead of all of these string-based lookups.
  */
 export function sameNode(node1: ASTNode, node2: ASTNode): boolean {
   const l1 = node1.__location, l2 = node2.__location;

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -119,7 +119,7 @@ export function parse(html: string, options: ParserOptions): ASTNode {
  * TODO(usergenic): Port this to `dom5` and do it with typings for location info
  * instead of all of these string-based lookups.
  */
-export function inOrder(left: ASTNode, right: ASTNode): boolean {
+export function inSourceOrder(left: ASTNode, right: ASTNode): boolean {
   const l = left.__location, r = right.__location;
   return l && r && l['line'] && r['line'] &&
       (l['line'] < r['line'] ||

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -254,8 +254,8 @@ export class Bundler {
   }
 
   /**
-   * Append a <link rel="import" node to `node` with a value of `url` for
-   * the "href" attribute.
+   * Append a `<link rel="import" ...>` node to `node` with a value of `url`
+   * for the "href" attribute.
    */
   private _createHtmlImport(url: UrlString): ASTNode {
     const link = dom5.constructors.element('link');

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -176,33 +176,6 @@ export class Bundler {
   }
 
   /**
-   * Add HTML Import elements for each file in the bundle.  We append all the
-   * imports in the case any were moved into the bundle by the strategy.
-   * While this will almost always yield duplicate imports, they will be
-   * cleaned up through deduplication during the import phase.
-   */
-  private _appendHtmlImportsForBundle(ast: ASTNode, bundle: AssignedBundle) {
-    for (const importUrl of bundle.bundle.files) {
-      const newUrl = urlUtils.relativeUrl(bundle.url, importUrl);
-      if (!newUrl) {
-        continue;
-      }
-      this._appendHtmlImport(this._findOrCreateHiddenDiv(ast), newUrl);
-    }
-  }
-
-  /**
-   * Append a <link rel="import" node to `node` with a value of `url` for
-   * the "href" attribute.
-   */
-  private _appendHtmlImport(ast: ASTNode, url: UrlString) {
-    const link = dom5.constructors.element('link');
-    dom5.setAttribute(link, 'rel', 'import');
-    dom5.setAttribute(link, 'href', url);
-    dom5.append(ast, link);
-  }
-
-  /**
    * Set the hidden div at the appropriate location within the document.  The
    * goal is to place the hidden div at the same place as the first html
    * import.  However, the div can't be placed in the `<head>` of the document
@@ -236,7 +209,7 @@ export class Bundler {
     let document = await this._prepareBundleDocument(docBundle);
     const ast = clone(document.parsedDocument.ast);
     dom5.removeFakeRootElements(ast);
-    this._appendHtmlImportsForBundle(ast, docBundle);
+    this._injectHtmlImportsForBundle(document, ast, docBundle, bundleManifest);
     importUtils.rewriteAstToEmulateBaseTag(
         ast, document.url, this.rewriteUrlsInTemplates);
 
@@ -281,6 +254,17 @@ export class Bundler {
   }
 
   /**
+   * Append a <link rel="import" node to `node` with a value of `url` for
+   * the "href" attribute.
+   */
+  private _createHtmlImport(url: UrlString): ASTNode {
+    const link = dom5.constructors.element('link');
+    dom5.setAttribute(link, 'rel', 'import');
+    dom5.setAttribute(link, 'href', url);
+    return link;
+  }
+
+  /**
    * Given an array of Bundles, remove all files from bundles which are in the
    * "excludes" set.  Remove any bundles which are left empty after excluded
    * files are removed.
@@ -321,6 +305,74 @@ export class Bundler {
       this._attachHiddenDiv(ast, hiddenDiv);
     }
     return hiddenDiv;
+  }
+
+  /**
+   * Add HTML Import elements for each file in the bundle.  Efforts are made to
+   * ensure that imports are injected prior to any eager imports of other
+   * bundles which are known to depend on them, to preserve expectations of
+   * evaluation order.
+   *
+   * We inject all imports in the case any were moved into the bundle by the
+   * strategy. While this will almost always yield duplicate imports, they
+   * will be cleaned up through deduplication during the import phase.
+   */
+  private _injectHtmlImportsForBundle(
+      document: Document,
+      ast: ASTNode,
+      bundle: AssignedBundle,
+      bundleManifest: BundleManifest) {
+    const existingImports = [...document.getFeatures(
+        {kind: 'html-import', noLazyImports: true, imported: false})];
+    const existingImportDependencies =
+        new Map(<[string, string[]][]>existingImports.map(
+            (existingImport) => [existingImport.document.url, [
+              ...existingImport.document.getFeatures(
+                  {kind: 'html-import', imported: true, noLazyImports: true})
+            ].map((feature) => feature.document.url)]));
+
+    for (const importUrl of bundle.bundle.files) {
+      const relativeImportUrl = urlUtils.relativeUrl(bundle.url, importUrl);
+
+      // If relative import url is empty, it is because the urls are the same,
+      // meaning we'd be importing the same document as ourself.  Skip.
+      if (!relativeImportUrl) {
+        continue;
+      }
+
+      // No need to inject an import that's already there.
+      if (existingImports.find((e) => e.document.url === importUrl)) {
+        continue;
+      }
+
+      let prependTarget = undefined;
+
+      for (const existingImport of existingImports.filter(
+               (e) => !bundle.bundle.files.has(e.document.url))) {
+        // If the existing import has a dependency on the import we are about
+        // to inject and that import is not a part of this bundle, lets inject
+        // the dependency before it.
+        if (existingImportDependencies.get(existingImport.document.url)!
+                .indexOf(importUrl) !== -1) {
+          const newPrependTarget = dom5.query(
+              ast, (node) => astUtils.sameNode(node, existingImport.astNode));
+          if (newPrependTarget &&
+              (!prependTarget ||
+               astUtils.inOrder(newPrependTarget, prependTarget))) {
+            prependTarget = newPrependTarget;
+          }
+        }
+      }
+
+      const newHtmlImport = this._createHtmlImport(relativeImportUrl);
+      if (prependTarget) {
+        dom5.insertBefore(
+            prependTarget.parentNode!, prependTarget, newHtmlImport);
+      } else {
+        const hiddenDiv = this._findOrCreateHiddenDiv(ast);
+        dom5.append(hiddenDiv.parentNode!, newHtmlImport);
+      }
+    }
   }
 
   /**

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -366,7 +366,7 @@ export class Bundler {
           // one.
           if (newPrependTarget &&
               (!prependTarget ||
-               astUtils.inOrder(newPrependTarget, prependTarget))) {
+               astUtils.inSourceOrder(newPrependTarget, prependTarget))) {
             prependTarget = newPrependTarget;
           }
         }

--- a/src/test/ast-utils_test.ts
+++ b/src/test/ast-utils_test.ts
@@ -28,18 +28,18 @@ const assert = chai.assert;
 
 suite('AST Utils', function() {
 
-  test('inOrder', () => {
+  test('inSourceOrder', () => {
     const html = parse5.parseFragment(`
           <span>oh</span><span>hi</span>
           <span>good</span>
         <span>bye</span>
       `, {locationInfo: true});
     const spans = dom5.queryAll(html, dom5.predicates.hasTagName('span'));
-    assert.isTrue(ast.inOrder(spans[0], spans[1]), 'oh -> hi');
-    assert.isTrue(ast.inOrder(spans[0], spans[3]), 'oh -> bye');
-    assert.isTrue(ast.inOrder(spans[2], spans[3]), 'good -> bye');
-    assert.isFalse(ast.inOrder(spans[3], spans[1]), 'bye <- hi');
-    assert.isFalse(ast.inOrder(spans[1], spans[0]), 'hi <- oh');
+    assert.isTrue(ast.inSourceOrder(spans[0], spans[1]), 'oh -> hi');
+    assert.isTrue(ast.inSourceOrder(spans[0], spans[3]), 'oh -> bye');
+    assert.isTrue(ast.inSourceOrder(spans[2], spans[3]), 'good -> bye');
+    assert.isFalse(ast.inSourceOrder(spans[3], spans[1]), 'bye <- hi');
+    assert.isFalse(ast.inSourceOrder(spans[1], spans[0]), 'hi <- oh');
   });
 
   test('prepend', () => {

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -20,7 +20,7 @@ import * as parse5 from 'parse5';
 import * as path from 'path';
 import {Analyzer, FSUrlLoader} from 'polymer-analyzer';
 
-import {Bundle} from '../bundle-manifest';
+import {Bundle, generateShellMergeStrategy} from '../bundle-manifest';
 import {Bundler, Options as BundlerOptions} from '../bundler';
 
 chai.config.showDiff = true;
@@ -88,7 +88,8 @@ suite('Bundler', () => {
       const bundler = new Bundler({
         inlineCss: true,
         inlineScripts: true,
-        // This strategy adds a file not in the original document to the bundle.
+        // This strategy adds a file not in the original document to the
+        // bundle.
         strategy: (bundles: Bundle[]): Bundle[] => {
           bundles.forEach((b) => {
             b.files.add('test/html/imports/external-script.html');
@@ -773,6 +774,33 @@ suite('Bundler', () => {
       assert(myElement);
       assert(preds.NOT(preds.parentMatches(
           preds.hasAttr('by-polymer-bundler')))(<parse5.ASTNode>myElement));
+    });
+
+    test('eagerly importing a fragment', async () => {
+      const bundler = new Bundler({
+        analyzer:
+            new Analyzer({urlLoader: new FSUrlLoader('test/html/imports')}),
+        strategy: generateShellMergeStrategy('importing-fragments/shell.html'),
+      });
+      const manifest = await bundler.generateManifest([
+        'eagerly-importing-a-fragment.html',
+        'importing-fragments/fragment-a.html',
+        'importing-fragments/fragment-b.html',
+        'importing-fragments/shell.html',
+      ]);
+      const result = await bundler.bundle(manifest);
+      assert.equal(result.manifest.bundles.size, 4);
+      const shell = parse5.serialize(
+          result.documents.get('importing-fragments/shell.html')!.ast);
+      const fragmentAAt = shell.indexOf('href="fragment-a.html"');
+      const shellAt = shell.indexOf(`console.log('shell.html')`);
+      const sharedUtilAt = shell.indexOf(`console.log('shared-util.html')`);
+      assert.isTrue(
+          sharedUtilAt < fragmentAAt,
+          'Inlined shared-util.html should come before fragment-a.html import');
+      assert.isTrue(
+          fragmentAAt < shellAt,
+          'fragment-a.html import should come before script in shell.html');
     });
 
     test.skip('Imports in templates should not inline', async () => {

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -37,6 +37,7 @@ suite('Bundler', () => {
   }
 
   suite('Deps index tests', () => {
+
     test('with 3 endpoints', async () => {
       const common = 'common.html';
       const dep1 = 'dep1.html';
@@ -85,6 +86,27 @@ suite('Bundler', () => {
         [deeply1, new Set([deeply1, deeply2])],
       ]);
       const index = await buildDepsIndex([entrypoint], analyzer);
+      chai.assert.deepEqual(
+          serializeMap(index.entrypointToDeps),
+          serializeMap(expectedEntrypointsToDeps));
+    });
+
+    test('when an entrypoint imports an entrypoint', async () => {
+      const entrypoint = 'eagerly-importing-a-fragment.html';
+      const fragmentA = 'importing-fragments/fragment-a.html';
+      const fragmentB = 'importing-fragments/fragment-a.html';
+      const util = 'importing-fragments/shared-util.html';
+      const shell = 'importing-fragments/shell.html';
+      const analyzer =
+          new Analyzer({urlLoader: new FSUrlLoader('test/html/imports')});
+      const expectedEntrypointsToDeps = new Map([
+        [entrypoint, new Set([entrypoint, fragmentA, shell, util])],
+        [fragmentA, new Set([fragmentA, util])],
+        [fragmentB, new Set([fragmentB, util])],
+        [shell, new Set([shell, fragmentA, util])],
+      ]);
+      const index = await buildDepsIndex(
+          [entrypoint, fragmentA, fragmentB, shell], analyzer);
       chai.assert.deepEqual(
           serializeMap(index.entrypointToDeps),
           serializeMap(expectedEntrypointsToDeps));

--- a/test/html/imports/eagerly-importing-a-fragment.html
+++ b/test/html/imports/eagerly-importing-a-fragment.html
@@ -1,0 +1,12 @@
+<!---
+The scenario is an app imports home.html which imports utils.html. home.html
+is specified as a fragment though, and then gets inlined before utils.html,
+causing runtime errors. Removing home.html as a fragment fixes the issue.
+-->
+
+<link rel="import" href="importing-fragments/shell.html">
+
+<script>
+  console.log('eagerly-importing-a-fragment.html');
+
+</script>

--- a/test/html/imports/importing-fragments/fragment-a.html
+++ b/test/html/imports/importing-fragments/fragment-a.html
@@ -1,0 +1,6 @@
+<link rel="import" href="shared-util.html">
+
+<script>
+  console.log('fragment-a.html');
+
+</script>

--- a/test/html/imports/importing-fragments/fragment-b.html
+++ b/test/html/imports/importing-fragments/fragment-b.html
@@ -1,0 +1,6 @@
+<link rel="import" href="shared-util.html">
+
+<script>
+  console.log('fragment-b.html');
+
+</script>

--- a/test/html/imports/importing-fragments/shared-util.html
+++ b/test/html/imports/importing-fragments/shared-util.html
@@ -1,0 +1,4 @@
+<script>
+  console.log('shared-util.html');
+
+</script>

--- a/test/html/imports/importing-fragments/shell.html
+++ b/test/html/imports/importing-fragments/shell.html
@@ -1,0 +1,5 @@
+<link rel="import" href="fragment-a.html">
+
+<script>
+  console.log('shell.html');
+</script>


### PR DESCRIPTION
- [x] CHANGELOG updated.
- Fixes https://github.com/Polymer/polymer-bundler/issues/517
- Added bundler tests to demonstrate where the problem exists when injecting html imports doesn't consider the order they are needed.
- See the test fail here https://github.com/Polymer/polymer-bundler/pull/528/commits/8f23344f421cd50d5f12fc60f8964c726ef46368
- See the test pass here https://github.com/Polymer/polymer-bundler/pull/528/commits/d234caedc3fc74bcd68a440c2118a27688971b74
