### PR TITLE
Fixes issues with lazy-imports, dom-modules and hidden divs #534 #535 #536

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Fixed issue with lazy-imports impacting bundle inlining logic. https://github.com/Polymer/polymer-bundler/issues/536
+- Fixed issue with hidden div being created inside dom-modules. https://github.com/Polymer/polymer-bundler/issues/535
+- Fixed issue with injected dependencies inside dom-modules in shell when using lazy-imports. https://github.com/Polymer/polymer-bundler/issues/534
+
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.2 - 2017-06-02

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -184,7 +184,7 @@ export class Bundler {
    * the end.
    */
   private _attachHiddenDiv(ast: ASTNode, hiddenDiv: ASTNode) {
-    const firstHtmlImport = dom5.query(ast, matchers.htmlImport);
+    const firstHtmlImport = dom5.query(ast, matchers.eagerHtmlImport);
     const body = dom5.query(ast, matchers.body);
     if (body) {
       if (firstHtmlImport &&
@@ -321,14 +321,16 @@ export class Bundler {
     // Gather all the document's direct html imports.  We want the direct (not
     // transitive) imports only here, because we'll be using their AST nodes as
     // targets to prepended injected imports to.
-    const existingImports = [...document.getFeatures(
-        {kind: 'html-import', noLazyImports: true, imported: false})];
+    const existingImports = [
+      ...document.getFeatures(
+          {kind: 'html-import', noLazyImports: true, imported: false})
+    ].filter((i) => !i.lazy);
     const existingImportDependencies =
         new Map(<[string, string[]][]>existingImports.map(
             (existingImport) => [existingImport.document.url, [
               ...existingImport.document.getFeatures(
                   {kind: 'html-import', imported: true, noLazyImports: true})
-            ].map((feature) => feature.document.url)]));
+            ].filter((i) => !i.lazy).map((feature) => feature.document.url)]));
 
     // Every file in the bundle is a candidate for injection into the document.
     for (const importUrl of bundle.bundle.files) {

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -54,15 +54,19 @@ export async function inlineHtmlImport(
   const resolvedImportUrl = analyzer.resolveUrl(importUrl);
   const importBundle = manifest.getBundleForFile(resolvedImportUrl);
 
-  // Don't reprocess the same file again.
-  if (visitedUrls.has(resolvedImportUrl)) {
-    astUtils.removeElementAndNewline(linkTag);
-    return;
-  }
+  // We don't want to process the same eager import again, but we want to
+  // process every lazy import we see.
+  if (!isLazy) {
+    // Don't reprocess the same file again.
+    if (visitedUrls.has(resolvedImportUrl)) {
+      astUtils.removeElementAndNewline(linkTag);
+      return;
+    }
 
-  // We've never seen this import before, so we'll add it to the set to guard
-  // against processing it again in the future.
-  visitedUrls.add(resolvedImportUrl);
+    // We've never seen this import before, so we'll add it to the set to guard
+    // against inlining it again in the future.
+    visitedUrls.add(resolvedImportUrl);
+  }
 
   // If we can't find a bundle for the referenced import, record that we've
   // processed it, but don't remove the import link.  Browser will handle it.

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -792,7 +792,7 @@ suite('Bundler', () => {
       assert.equal(result.manifest.bundles.size, 4);
       const shell = parse5.serialize(
           result.documents.get('importing-fragments/shell.html')!.ast);
-      const fragmentAAt = shell.indexOf('href="fragment-a.html"');
+      const fragmentAAt = shell.indexOf('rel="import" href="fragment-a.html"');
       const shellAt = shell.indexOf(`console.log('shell.html')`);
       const sharedUtilAt = shell.indexOf(`console.log('shared-util.html')`);
       assert.isTrue(

--- a/test/html/imports/importing-fragments/shell.html
+++ b/test/html/imports/importing-fragments/shell.html
@@ -1,5 +1,8 @@
-<link rel="import" href="fragment-a.html">
+<dom-module id="shell">
+  <link rel="lazy-import" href="fragment-a.html">
+  <script>
+    console.log('shell.html');
+  </script>
+</dom-module>
 
-<script>
-  console.log('shell.html');
-</script>
+<link rel="import" href="fragment-a.html">


### PR DESCRIPTION
These bugs were introduced, or rather, they became highly visible, as a result of a recent release of bundler containing https://github.com/Polymer/polymer-bundler/pull/528

This impacts PSK and other shell-based builds in the wild, so is highly critical to fix and release.

- Fixed issue with lazy-imports impacting bundle inlining logic. https://github.com/Polymer/polymer-bundler/issues/536
- Fixed issue with hidden div being created inside dom-modules. https://github.com/Polymer/polymer-bundler/issues/535
- Fixed issue with injected dependencies inside dom-modules in shell when using lazy-imports. https://github.com/Polymer/polymer-bundler/issues/534
- [x] CHANGELOG.md has been updated
