### PR TITLE
fix #531: URLs in inlined stylesheets are rewritten incorrectly when they refer out of the build root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Fixed issue with incorrect URL rewrites in inlined CSS (when URL points outside of the package root). https://github.com/Polymer/polymer-bundler/issues/531
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.3 - 2017-06-07

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -100,6 +100,15 @@ suite('URL Utils', () => {
       testRewrite(
           'foo.html', 'bar.html', 'index.html', 'foo.html', 'neither has ^/');
     });
+
+    test('Rewrite URLs pointing outside of the build root', () => {
+      testRewrite(
+          '../../images/icon.svg',
+          'css/foo.css',
+          'foo.html',
+          '../images/icon.svg',
+          'neither has ^/');
+    });
   });
 
   suite('Relative URL calculations', () => {

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -103,9 +103,13 @@ export function rewriteHrefBaseUrl(
   const parsedTo = url.parse(absUrl);
   if (parsedFrom.protocol === parsedTo.protocol &&
       parsedFrom.host === parsedTo.host) {
-    const pathname = path.posix.relative(
-        makeAbsolutePath(path.posix.dirname(parsedFrom.pathname || '')),
-        makeAbsolutePath(parsedTo.pathname || ''));
+    let dirFrom = path.posix.dirname(parsedFrom.pathname || '');
+    let pathTo = parsedTo.pathname || '';
+    if (isAbsolutePath(oldBaseUrl) || isAbsolutePath(newBaseUrl)) {
+      dirFrom = makeAbsolutePath(dirFrom);
+      pathTo = makeAbsolutePath(pathTo);
+    }
+    const pathname = path.posix.relative(dirFrom, pathTo);
     return url.format(
         {pathname: pathname, search: parsedTo.search, hash: parsedTo.hash});
   }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -116,6 +116,6 @@ export function rewriteHrefBaseUrl(
   return absUrl;
 }
 
-function makeAbsolutePath(pathStr: string): string {
-  return pathStr.startsWith(path.sep) ? pathStr : path.sep + pathStr;
+function makeAbsolutePath(path: string): string {
+  return path.startsWith('/') ? path : '/' + path;
 }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -116,6 +116,6 @@ export function rewriteHrefBaseUrl(
   return absUrl;
 }
 
-function makeAbsolutePath(path: string): string {
-  return path.startsWith('/') ? path : '/' + path;
+function makeAbsolutePath(pathStr: string): string {
+  return pathStr.startsWith(path.sep) ? pathStr : path.sep + pathStr;
 }


### PR DESCRIPTION
This fix applies only when both the old and the new base URLs are relative (because otherwise referring outside of the build root is incorrect):
- add a test verifying the relative URL rewrites handles out-of-build-root URLs
- add a special handling for the case when both the new and the old base URLs are relative and run all path-related logic in relative paths then

 - [x] CHANGELOG.md has been updated
