### PR TITLE
Added a --root|-r option to set the project root when calling polymer-bundler CLI.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - Added a `--redirect` option to `bin/polymer-bundler`.
+- Added a `--root` option to `bin/polymer-bundler`.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.0.3 - 2017-06-07

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ for this step).
 ## Options
 - `-h`|`--help`: Print this message
 - `-v`|`--version`: Print version number
+- `-r`|`--root`: The root of the package/project being bundled.  Defaults to the current working folder.
 - `--exclude <path>`: Exclude a subpath from root. Use multiple times to exclude multiple paths. Tags (imports/scripts/etc) that reference an excluded path are left in-place, meaning the resources are not inlined. ex: `--exclude=elements/x-foo.html --exclude=elements/x-bar.html`
 - `--inline-scripts`: Inline external scripts.
 - `--inline-css`: Inline external stylesheets.

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -26,7 +26,6 @@ import {generateShellMergeStrategy} from '../bundle-manifest';
 
 const prefixArgument = '[underline]{prefix}';
 const pathArgument = '[underline]{path}';
-const projectRoot = pathLib.resolve('.');
 
 const optionDefinitions = [
   {name: 'help', type: Boolean, alias: 'h', description: 'Print this message'},
@@ -113,7 +112,16 @@ const optionDefinitions = [
     name: 'sourcemaps',
     type: Boolean,
     description: 'Create and process sourcemaps for scripts.'
-  }
+  },
+  {
+    name: 'root',
+    alias: 'r',
+    type: String,
+    typeLabel: pathArgument,
+    description:
+        'The root of the package/project being bundled.  Defaults to the ' +
+        'current working folder.'
+  },
 ];
 
 const usage = [
@@ -152,6 +160,8 @@ const usage = [
 ];
 
 const options = commandLineArgs(optionDefinitions);
+const projectRoot =
+    options.root ? pathLib.resolve(options.root) : pathLib.resolve('.');
 
 const entrypoints: UrlString[] = options['in-html'];
 
@@ -205,6 +215,10 @@ if (options.redirect) {
           new MultiUrlLoader([...loaders, new FSUrlLoader(projectRoot)])
     });
   }
+}
+
+if (!options.analyzer) {
+  options.analyzer = new Analyzer({urlLoader: new FSUrlLoader(projectRoot)});
 }
 
 if (options.shell) {

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -37,6 +37,15 @@ suite('polymer-bundler CLI', () => {
     assert.include(stdout, 'hello from /absolute-paths/script.js');
   });
 
+  test('uses the --root value option as loader root', async () => {
+    const stdout = execSync([
+                     `node ${cliPath} --root test/html absolute-paths.html`,
+                   ].join(' && '))
+                       .toString();
+    assert.include(stdout, '.absolute-paths-style');
+    assert.include(stdout, 'hello from /absolute-paths/script.js');
+  });
+
   suite('--redirect', () => {
 
     test('handles urls with arbitrary protocols and hosts', async () => {


### PR DESCRIPTION
 - Now you can set the project root instead of it just always being current working directory.
 - [x] CHANGELOG.md has been updated
