### PR TITLE
Don't add the `original` property to a mapping unless one exists (#519)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Fixed error when generating source maps due to original line or column not being available.
 - Added a `--redirect` option to `bin/polymer-bundler`.
 - Added a `--root` option to `bin/polymer-bundler`.
 - The `stripComments` behavior now removes comments inside templates.

--- a/src/source-map.ts
+++ b/src/source-map.ts
@@ -83,13 +83,16 @@ function offsetSourceMap(
   consumer.eachMapping(mapping => {
     const newMapping: any = {
       source: mapping.source,
-      original: {line: mapping.originalLine, column: mapping.originalColumn},
       generated: {
         line: mapping.generatedLine + lineOffset,
         column: mapping.generatedColumn +
             (mapping.generatedLine === 1 ? firstLineCharOffset : 0)
       }
     };
+
+    if (typeof mapping.originalLine === 'number' && typeof mapping.originalColumn === 'number') {
+      newMapping.original = { line: mapping.originalLine, column: mapping.originalColumn };
+    }
 
     if (mapping.name) {
       newMapping.name = mapping.name;

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -116,7 +116,7 @@ suite('Bundler', () => {
       assert(doc);
       const compiledHtml = parse5.serialize(doc);
       const inlineScripts = dom5.queryAll(doc, matchers.inlineJavascript);
-      assert.equal(inlineScripts.length, 2);
+      assert.equal(inlineScripts.length, 3);
 
       for (let i = 0; i < inlineScripts.length; i++) {
         const sourcemap = await getExistingSourcemap(
@@ -134,7 +134,7 @@ suite('Bundler', () => {
       assert(doc);
       const compiledHtml = parse5.serialize(doc);
       const inlineScripts = dom5.queryAll(doc, matchers.inlineJavascript);
-      assert.equal(inlineScripts.length, 6);
+      assert.equal(inlineScripts.length, 7);
 
       for (let i = 0; i < inlineScripts.length; i++) {
         const sourcemap = await getExistingSourcemap(

--- a/test/html/sourcemaps/external.html
+++ b/test/html/sourcemaps/external.html
@@ -1,3 +1,4 @@
 <!DOCTYPE html>
 <link rel="import" href="external/no-map.html">
 <link rel="import" href="external/has-map.html">
+<link rel="import" href="external/nested-with-babel-map/has-babel-map.html">

--- a/test/html/sourcemaps/external/babel-map.js
+++ b/test/html/sourcemaps/external/babel-map.js
@@ -1,0 +1,2 @@
+console.log();
+//# sourceMappingURL=data:application/json;charset=utf8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbImJhYmVsLW1hcC5qcyJdLCJuYW1lcyI6WyJjb25zb2xlIiwibG9nIl0sIm1hcHBpbmdzIjoiQUFBQUEsUUFBUUMsR0FBUixFIiwiZmlsZSI6ImJhYmVsLW1hcC5qcyIsInNvdXJjZXNDb250ZW50IjpbImNvbnNvbGUubG9nKCk7XG4iXX0=

--- a/test/html/sourcemaps/external/nested-with-babel-map/has-babel-map.html
+++ b/test/html/sourcemaps/external/nested-with-babel-map/has-babel-map.html
@@ -1,0 +1,1 @@
+<script src="../babel-map.js"></script>


### PR DESCRIPTION
 - Fixed an error when generating source maps where `original.line` and/or `original.column` were not given.
 - Don't add the `original` property to a mapping unless one exists. This is needed for mappings to pass the `_validateMapping` check in https://github.com/mozilla/source-map/blob/master/lib/source-map-generator.js#L264
 - Fixes #516
 - [x] CHANGELOG.md has been updated
