### PR TITLE
Do not inline unless options are set in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
+- Fixed the `--inline-scripts` and `--inline-css` options, previously inlining happened regardless of whether the options were actually set
 
 ## 2.1.0 - 2017-06-14
 - Added a `--redirect` option to `bin/polymer-bundler`.

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -187,8 +187,8 @@ if (options.help || !entrypoints) {
 options.excludes = options.exclude || [];
 options.stripComments = options['strip-comments'];
 options.implicitStrip = !options['no-implicit-strip'];
-options.inlineScripts = options['inline-scripts'];
-options.inlineCss = options['inline-css'];
+options.inlineScripts = Boolean(options['inline-scripts']);
+options.inlineCss = Boolean(options['inline-css']);
 
 if (options.redirect) {
   type redirection = {prefix: string, path: string};

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -32,7 +32,7 @@ suite('polymer-bundler CLI', () => {
     const projectRoot = path.resolve(__dirname, '../../test/html');
     const stdout = execSync(
                        `cd ${projectRoot} && ` +
-                       `node ${cliPath} absolute-paths.html`)
+                       `node ${cliPath} --inline-scripts --inline-css absolute-paths.html`)
                        .toString();
     assert.include(stdout, '.absolute-paths-style');
     assert.include(stdout, 'hello from /absolute-paths/script.js');
@@ -40,11 +40,20 @@ suite('polymer-bundler CLI', () => {
 
   test('uses the --root value option as loader root', async () => {
     const stdout = execSync([
-                     `node ${cliPath} --root test/html absolute-paths.html`,
+                     `node ${cliPath} --root test/html --inline-scripts --inline-css absolute-paths.html`,
                    ].join(' && '))
                        .toString();
     assert.include(stdout, '.absolute-paths-style');
     assert.include(stdout, 'hello from /absolute-paths/script.js');
+  });
+
+  test('Does not inline if --inline-scripts or --inline-css are not set', async () => {
+    const stdout = execSync([
+                     `node ${cliPath} test/html/external.html`,
+                   ].join(' && '))
+                       .toString();
+    assert.include(stdout, 'href="external/external.css"');
+    assert.include(stdout, 'src="external/external.js"');
   });
 
   suite('--manifest-out', () => {
@@ -55,7 +64,7 @@ suite('polymer-bundler CLI', () => {
       const manifestPath = path.join(tempdir, 'bundle-manifest.json');
       execSync(
           `cd ${projectRoot} && ` +
-          `node ${cliPath} absolute-paths.html ` +
+          `node ${cliPath} --inline-scripts --inline-css absolute-paths.html ` +
           `--manifest-out ${manifestPath}`)
           .toString();
       const manifestJson = fs.readFileSync(manifestPath).toString();


### PR DESCRIPTION
Fixed the `--inline-scripts` and `--inline-css` options, previously inlining happened regardless of whether the options were actually set.

Without the coercion to Boolean, the options were `undefined`, and
`undefined` is interpreted as `true` by the bundler because inlining is the
default.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated
