### PR TITLE
Update the handling of the `--out-dir` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Fixed issue where absolute paths were not handled properly. https://github.com/Polymer/polymer-bundler/issues/559
+- Fixed issue where out-dir was essentially ignored for a single bundle case. https://github.com/Polymer/polymer-bundler/issues/560
 <!-- Add new, unreleased changes here. -->
 
 ## 2.1.0 - 2017-06-14

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -279,15 +279,15 @@ function bundleManifestToJson(manifest: BundleManifest): JsonManifest {
     fs.writeSync(fd, JSON.stringify(manifestJson));
     fs.closeSync(fd);
   }
-  if (documents.size > 1) {
-    const outDir = options['out-dir'];
+  const outDir = options['out-dir'];
+  if (documents.size > 1 || outDir) {
     if (!outDir) {
       throw new Error(
           'Must specify out-dir when bundling multiple entrypoints');
     }
     for (const [url, document] of documents) {
       const ast = document.ast;
-      const out = pathLib.join(process.cwd(), outDir, url);
+      const out = pathLib.resolve(pathLib.join(outDir, url));
       const finalDir = pathLib.dirname(out);
       mkdirp.sync(finalDir);
       const serialized = parse5.serialize(ast);

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -47,6 +47,22 @@ suite('polymer-bundler CLI', () => {
     assert.include(stdout, 'hello from /absolute-paths/script.js');
   });
 
+  suite('--out-dir', () => {
+
+    test('writes to the dir even for single bundle', async () => {
+      const projectRoot = path.resolve(__dirname, '../../test/html');
+      const tempdir = fs.mkdtempSync(path.join(os.tmpdir(), ' ').trim());
+      execSync(
+          `cd ${projectRoot} && ` +
+          `node ${cliPath} absolute-paths.html ` +
+          `--out-dir ${tempdir}`)
+          .toString();
+      const html =
+          fs.readFileSync(path.join(tempdir, 'absolute-paths.html')).toString();
+      assert.notEqual(html, '');
+    });
+  });
+
   suite('--manifest-out', () => {
 
     test('writes out the bundle manifest to given path', async () => {


### PR DESCRIPTION
- Fixed issue where absolute paths were not handled properly. https://github.com/Polymer/polymer-bundler/issues/559
- Fixed issue where out-dir was essentially ignored for a single bundle case. https://github.com/Polymer/polymer-bundler/issues/560
- [x] CHANGELOG.md has been updated
