### PR TITLE
polymer-analyzer version mismatch stopgap.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed issue producing assetpath in application root. https://github.com/Polymer/polymer-bundler/issues/562
 - Fixed issue where absolute paths were not handled properly. https://github.com/Polymer/polymer-bundler/issues/559
 - Fixed issue where out-dir was essentially ignored for a single bundle case. https://github.com/Polymer/polymer-bundler/issues/560
+- Fixed issue where, if a different version of polymer-analyzer was given to Bundler's constructor, it caused instanceof check failures and resulting in documents not being identified as documents; added more definitive error messaging for this scenario as stop-gap until we switch to a no instanceof version of polymer-analyzer interface.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.1.0 - 2017-06-14

--- a/src/analyzer-utils.ts
+++ b/src/analyzer-utils.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt
+ * The complete set of authors may be found at
+ * http://polymer.github.io/AUTHORS.txt
+ * The complete set of contributors may be found at
+ * http://polymer.github.io/CONTRIBUTORS.txt
+ * Code distributed by Google as part of the polymer project is also
+ * subject to an additional IP rights grant found at
+ * http://polymer.github.io/PATENTS.txt
+ */
+import {Analysis, Document, Warning} from 'polymer-analyzer';
+
+export function getAnalysisDocument(analysis: Analysis, url: string): Document {
+  const document = analysis.getDocument(url);
+  if (document instanceof Document) {
+    return document;
+  }
+  if (document instanceof Warning || !document) {
+    const reason = document && document.message || 'unknown';
+    const message = `Unable to get document ${url}: ${reason}`;
+    throw new Error(message);
+  }
+  throw new Error(
+      `Bundler was given a different version of polymer-analyzer than ` +
+      `expected.  Please ensure only one version of polymer-analyzer ` +
+      `present in node_modules folder:\n\n` +
+      `$ npm ls polymer- analyzer`);
+}

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -17,6 +17,7 @@ import * as parse5 from 'parse5';
 import {ASTNode, serialize, treeAdapters} from 'parse5';
 import * as path from 'path';
 import {Analyzer, Document, FSUrlLoader, InMemoryOverlayUrlLoader} from 'polymer-analyzer';
+import {getAnalysisDocument} from './analyzer-utils';
 
 import * as astUtils from './ast-utils';
 import * as bundleManifestLib from './bundle-manifest';
@@ -167,12 +168,7 @@ export class Bundler {
     this._overlayUrlLoader.urlContentsMap.set(url, contents);
     await this.analyzer.filesChanged([url]);
     const analysis = await this.analyzer.analyze([url]);
-    const document = analysis.getDocument(url);
-    if (!(document instanceof Document)) {
-      const message = document && document.message || 'unknown';
-      throw new Error(`Unable to get document ${url}: ${message}`);
-    }
-    return document;
+    return getAnalysisDocument(analysis, url);
   }
 
   /**
@@ -549,11 +545,7 @@ export class Bundler {
       return this._analyzeContents(bundle.url, '');
     }
     const analysis = await this.analyzer.analyze([bundle.url]);
-    const document = analysis.getDocument(bundle.url);
-    if (!(document instanceof Document)) {
-      const message = document && document.message || 'unknown';
-      throw new Error(`Unable to get document ${bundle.url}: ${message}`);
-    }
+    const document = getAnalysisDocument(analysis, bundle.url);
     const ast = clone(document.parsedDocument.ast);
     this._moveOrderedImperativesFromHeadIntoHiddenDiv(ast);
     this._moveUnhiddenHtmlImportsIntoHiddenDiv(ast);


### PR DESCRIPTION
 - Better error messaging when a different version of polymer-analyzer is used in bundler's constructor.  A bundler-specific fix for what https://github.com/Polymer/polymer-analyzer/pull/686 tries to fix in polymer-analyzer itself.
 - [x] CHANGELOG.md has been updated
