### PR TITLE
Perform sufficient interface check on Warning values from Analyzer

### DIFF
--- a/src/analyzer-utils.ts
+++ b/src/analyzer-utils.ts
@@ -18,7 +18,9 @@ export function getAnalysisDocument(analysis: Analysis, url: string): Document {
   if (document instanceof Document) {
     return document;
   }
-  if (document instanceof Warning || !document) {
+  if (document instanceof Warning || !document ||
+      (typeof document === 'object' && document['code'] &&
+       document['message'])) {
     const reason = document && document.message || 'unknown';
     const message = `Unable to get document ${url}: ${reason}`;
     throw new Error(message);


### PR DESCRIPTION
 - This fixes an unreleased integration bug introduced by https://github.com/Polymer/polymer-bundler/pull/567
 - The code that checks for instanceof Warning is flawed *because* Analyzer delivers many Warnings as generic objects, passing typecheck purely by interface.  Bad Analyzer!  This fixes that by looking for code and message properties.
 - CHANGELOG.md doesn't need updating.  