### PR TITLE
Update CHANGELOG and package-lock.json for 2.1.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
 
-## 2.2.0 - 2017-06-28
+## 2.1.1 - 2017-06-28
 - Fixed the `--inline-scripts` and `--inline-css` options, previously inlining happened regardless of whether the options were actually set.  Important, if you use the `bin/polymer-bundler` CLI you must provide these options to inline scripts and css now.
 - Fixed issue producing assetpath in application root. https://github.com/Polymer/polymer-bundler/issues/562
 - Fixed issue where absolute paths were not handled properly. https://github.com/Polymer/polymer-bundler/issues/559

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+<!-- Add new, unreleased changes here. -->
+
+## 2.2.0 - 2017-06-28
+- Fixed the `--inline-scripts` and `--inline-css` options, previously inlining happened regardless of whether the options were actually set.  Important, if you use the `bin/polymer-bundler` CLI you must provide these options to inline scripts and css now.
 - Fixed issue producing assetpath in application root. https://github.com/Polymer/polymer-bundler/issues/562
 - Fixed issue where absolute paths were not handled properly. https://github.com/Polymer/polymer-bundler/issues/559
 - Fixed issue where out-dir was essentially ignored for a single bundle case. https://github.com/Polymer/polymer-bundler/issues/560
 - Fixed issue where, if a different version of polymer-analyzer was given to Bundler's constructor, it caused instanceof check failures and resulting in documents not being identified as documents; added more definitive error messaging for this scenario as stop-gap until we switch to a no instanceof version of polymer-analyzer interface.
-<!-- Add new, unreleased changes here. -->
-- Fixed the `--inline-scripts` and `--inline-css` options, previously inlining happened regardless of whether the options were actually set
 
 ## 2.1.0 - 2017-06-14
 - Added a `--redirect` option to `bin/polymer-bundler`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,9 +15,9 @@
       "integrity": "sha1-dM7M7zsvwtpzkbcT3rcv6afl94I=",
       "dependencies": {
         "@types/chai": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.0.tgz",
-          "integrity": "sha512-B56eI1x+Av9A7XHsgF0+WyLyBytAQqvdBoaULY3c4TGeKwLm43myB78EeBA8/VQn74KblXM4/ecmjTJJXUUF1A=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
+          "integrity": "sha512-DWrdkraJO+KvBB7+Jc6AuDd2+fwV6Z9iK8cqEEoYpcurYrH7GiUZmwjFuQIIWj5HhFz6NsSxdN72YMIHT7Fy2Q=="
         }
       }
     },
@@ -58,9 +58,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.77",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.77.tgz",
-      "integrity": "sha512-VgifFhOC+P5Zv2CgD1ZanuoL/rNqHZ7ubQUXpaVvRCynSiqX+wvLf6e1qR3+CpmDbfhcRM917bXYmhDEiIl+XA=="
+      "version": "6.0.78",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.78.tgz",
+      "integrity": "sha512-+vD6E8ixntRzzZukoF3uP1iV+ZjVN3koTcaeK+BEoc/kSfGbLDIGC7RmCaUgVpUfN6cWvfczFRERCyKM9mkvXg=="
     },
     "@types/parse5": {
       "version": "2.2.34",
@@ -207,9 +207,9 @@
       "dev": true
     },
     "balanced-match": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-      "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "bluebird": {
@@ -225,9 +225,9 @@
       "dev": true
     },
     "brace-expansion": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
-      "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true
     },
     "caller-path": {
@@ -501,9 +501,9 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.22",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.22.tgz",
-      "integrity": "sha512-YXTXSlZkJsVwMEVljp1Bh5P9+Raa3524OMl9kywGMp1aazKTCnAqORRL/8dkuqNHk+LRYe0LezuS8PlUt3+mOw==",
+      "version": "0.10.23",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
       "dev": true
     },
     "es6-iterator": {
@@ -590,18 +590,10 @@
       "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
     },
     "esrecurse": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
-      "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
-      "dev": true,
-      "dependencies": {
-        "estraverse": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
-          "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
-          "dev": true
-        }
-      }
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -685,17 +677,20 @@
       "dev": true,
       "dependencies": {
         "faye-websocket": {
-          "version": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
           "integrity": "sha1-SCpQWw3wrmJrlphm0710DNuWLoM=",
           "dev": true,
           "dependencies": {
             "websocket-driver": {
-              "version": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.2.tgz",
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.2.tgz",
               "integrity": "sha1-jHyF2gcTtAYFVrTXHAF3XuEmnrk=",
               "dev": true,
               "dependencies": {
                 "websocket-extensions": {
-                  "version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
                   "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
                   "dev": true
                 }
@@ -712,9 +707,9 @@
       "dev": true
     },
     "form-data": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-      "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
+      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
       "dev": true
     },
     "fs.realpath": {
@@ -748,9 +743,9 @@
       "dev": true
     },
     "globals": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.17.0.tgz",
-      "integrity": "sha1-DAymltm5u2lNLlRwvTd3fKrVAoY=",
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -1344,9 +1339,9 @@
       "dev": true
     },
     "polymer-analyzer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.0.2.tgz",
-      "integrity": "sha1-LB2HEdNnS024oI4Rs4IhfGsEL0Q="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.2.0.tgz",
+      "integrity": "sha512-jdCa48FYjMG+8K7zspqPtZH7fpJ5atY9obnMs7Z5gDvlZM9Qh4rek7NJzsMkdmxzhPcdeHMtaLP1GdYwq6B/Gg=="
     },
     "popsicle": {
       "version": "8.2.0",
@@ -1440,9 +1435,9 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
-      "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.2.tgz",
+      "integrity": "sha1-WgTfBeT1f+Pw3Gj90R3FyXx+b00=",
       "dev": true
     },
     "readline2": {
@@ -1523,9 +1518,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
-      "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
     },
     "semver": {
@@ -1593,9 +1588,9 @@
       "dev": true
     },
     "string_decoder": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
-      "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "dev": true
     },
     "string-template": {
@@ -1643,6 +1638,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -1650,9 +1651,15 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
+          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true
         }
       }
@@ -1680,9 +1687,9 @@
       "dev": true
     },
     "throat": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/throat/-/throat-3.0.0.tgz",
-      "integrity": "sha1-58ZMhny7OEXxCHdkL3tgBVuOwNY=",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
       "dev": true
     },
     "through": {
@@ -1759,9 +1766,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
-      "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
+      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw="
     },
     "typical": {
       "version": "2.6.1",


### PR DESCRIPTION
## 2.1.1 - 2017-06-28
 - Fixed the `--inline-scripts` and `--inline-css` options, previously inlining happened regardless of whether the options were actually set.  Important, if you use the `bin/polymer-bundler` CLI you must provide these options to inline scripts and css now.
 - Fixed issue producing assetpath in application root. https://github.com/Polymer/polymer-bundler/issues/562		 
 - Fixed issue where absolute paths were not handled properly. https://github.com/Polymer/polymer-bundler/issues/559
 - Fixed issue where out-dir was essentially ignored for a single bundle case. https://github.com/Polymer/polymer-bundler/issues/560
 - Fixed issue where, if a different version of polymer-analyzer was given to Bundler's constructor, it caused instanceof check failures and resulting in documents not being identified as documents; added more definitive error messaging for this scenario as stop-gap until we switch to a no instanceof version of polymer-analyzer interface.
 - [x] CHANGELOG.md has been updated
