### PR TITLE
Make sure inlined style imports are ordered correctly

### DIFF
--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -82,6 +82,15 @@ function buildLoader(config) {
   return loader;
 }
 
+function nextSibling(node) {
+  var parentNode = node.parentNode;
+  if (!parentNode) {
+    return null;
+  }
+  var idx = parentNode.childNodes.indexOf(node);
+  return parentNode.childNodes[idx + 1] || null;
+}
+
 var Vulcan = function Vulcan(opts) {
     // implicitStrip should be true by default
   this.implicitStrip = opts.implicitStrip === undefined ? true : Boolean(opts.implicitStrip);
@@ -365,6 +374,7 @@ Vulcan.prototype = {
 
   // inline scripts into document, returns a promise resolving to document.
   inlineCss: function inlineCss(doc, href) {
+    var lastPolymerExternalStyle = null;
     var css_links = dom5.queryAll(doc, matchers.ALL_CSS_LINK);
     var cssPromises = css_links.map(function(link) {
       var tag = link;
@@ -400,8 +410,14 @@ Vulcan.prototype = {
                 dom5.append(ownerDomModule, domTemplate);
               }
               dom5.remove(tag);
-              // put the style at the top of the dom-module's template
-              this.prepend(domTemplate.childNodes[0], style);
+              if (!lastPolymerExternalStyle) {
+                // put the style at the top of the dom-module's template
+                this.prepend(domTemplate.childNodes[0], style);
+              } else {
+                // put this style behind the last polymer external style
+                dom5.insertBefore(domTemplate.childNodes[0], nextSibling(lastPolymerExternalStyle), style);
+              }
+              lastPolymerExternalStyle = style;
             }
           } else {
             dom5.replace(tag, style);

--- a/test/html/imports/url-style-2.css
+++ b/test/html/imports/url-style-2.css
@@ -1,0 +1,12 @@
+/**
+  * @license
+  * Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+  * This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+  * The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+  * The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+  * Code distributed by Google as part of the polymer project is also
+  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+  */
+:root {
+  background-color: blue;
+}

--- a/test/html/style-order-test-doc.html
+++ b/test/html/style-order-test-doc.html
@@ -22,5 +22,11 @@
   <style type="text/css">
     .from-style-in-doc-body { color: green; }
   </style>
+  <dom-module id="x-foo">
+    <template>
+      <link rel="import" type="css" href="imports/url-style.css">
+      <link rel="import" type="css" href="imports/url-style-2.css">
+    </template>
+  </dom-module>
 </body>
 </html>

--- a/test/test.js
+++ b/test/test.js
@@ -748,7 +748,7 @@ suite('Vulcan', function() {
         if (err) {
           return done(err);
         }
-        var script = dom5.query(doc, 
+        var script = dom5.query(doc,
           preds.AND(
             preds.hasTagName('script'),
             preds.hasAttrValue('src', 'external/external.js')));
@@ -783,7 +783,7 @@ suite('Vulcan', function() {
         if (err) {
           return done(err);
         }
-        var script = dom5.query(doc, 
+        var script = dom5.query(doc,
           preds.AND(
             preds.hasTagName('script'),
             preds.hasAttrValue('src', 'external/external.js')));
@@ -1091,13 +1091,16 @@ suite('Vulcan', function() {
         var styles = dom5.queryAll(doc, dom5.predicates.hasTagName('style'));
         var rules = styles.map(function(s) {
           return dom5.serialize(s).trim();
-        }).join('\n').match(/\.[a-z-]+/g);
+        }).join('\n').match(/[:.][a-z-]+ \{/g);
         assert.deepEqual(rules, [
-          '.from-doc-linked-style',
-          '.from-import-linked-style',
-          '.from-import-inline-style',
-          '.from-style-in-doc-head',
-          '.from-style-in-doc-body'
+          '.from-doc-linked-style {',
+          '.from-import-linked-style {',
+          '.from-import-inline-style {',
+          '.from-style-in-doc-head {',
+          '.from-style-in-doc-body {',
+          ':host {',
+          '.rows {',
+          ':root {'
         ]);
         done();
       };


### PR DESCRIPTION
Previously, `<link rel="import" type="css">` styles were inlined by
prepending to the top of the `<dom-module>` template.

However, if there were multiple imports, the order would be reversed,
which can cause incorrect styling when overriding.

This commit makes sure the order remains correct for multiple style
imports.

Fixes #575