### PR TITLE
Updated style inlining to consider dom-module assetpath and limit <style> content rewriting to tags outside dom-module.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
-  - "5"
+  - "6"
+  - "node"
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Fix erroneously reverse-order inlining of style imports `<link rel="import" type="css">`.
+- Fix erroneously rewritten urls in inlined html imports containing `<style>` tags inside `<dom-module>` containers.
+- Fix invalid urls inside inlined style imports, which did not take into consideration container `<dom-module>` assetpath property.
+
 ## 1.15.5 - 2017-06-01
 - Add --out-request-list to bin/vulcanize help message
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - Fix erroneously reverse-order inlining of style imports `<link rel="import" type="css">`.
-- Added `--polymer2` flag that changes some of the rewriting behaviors to support the fact that Polymer 2.x honors the `assetpath` of `<dom-module>` when interpreting style urls.
-- Disables rewriting urls in inlined html imports containing `<style>` tags inside `<dom-module>` containers.
-- Include consideration of container `<dom-module>` `assetpath` property when rewriting urls inside inlined style imports.
+- Added `--polymer2` flag that changes some of the rewriting behaviors to support the fact that Polymer 2.x honors the `assetpath` of `<dom-module>` when interpreting style urls:
+  - Disables rewriting urls in inlined html imports containing `<style>` tags inside `<dom-module>` containers.
+  - Include consideration of container `<dom-module>` `assetpath` property when rewriting urls inside inlined style imports.
 
 ## 1.15.5 - 2017-06-01
 - Add --out-request-list to bin/vulcanize help message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - Fix erroneously reverse-order inlining of style imports `<link rel="import" type="css">`.
-- Fix erroneously rewritten urls in inlined html imports containing `<style>` tags inside `<dom-module>` containers.
-- Fix invalid urls inside inlined style imports, which did not take into consideration container `<dom-module>` assetpath property.
+- Added `--polymer2` flag that changes some of the rewriting behaviors to support the fact that Polymer 2.x honors the `assetpath` of `<dom-module>` when interpreting style urls.
+- Disables rewriting urls in inlined html imports containing `<style>` tags inside `<dom-module>` containers.
+- Include consideration of container `<dom-module>` `assetpath` property when rewriting urls inside inlined style imports.
 
 ## 1.15.5 - 2017-06-01
 - Add --out-request-list to bin/vulcanize help message

--- a/bin/vulcanize
+++ b/bin/vulcanize
@@ -35,7 +35,8 @@ var help = [
   '  --redirect <uri>|<path>: Takes an argument in the form of URI|PATH where url is a URI composed of a protocol, hostname, and path and PATH is a local filesystem path to replace the matched URI part with. Multiple redirects may be specified; the earliest ones have the highest priority.',
   '  --no-implicit-strip: DANGEROUS! Avoid stripping imports of the transitive dependencies of imports specified with `--exclude`. May result in duplicate javascript inlining.',
   '  --out-html <path>: If specified, output will be written to <path> instead of stdout.',
-  '  --out-request-list <path>`: Writes a list of request URLs required to vulcanize <html file> to <path> on success.',
+  '  --out-request-list <path>: Writes a list of request URLs required to vulcanize <html file> to <path> on success.',
+  '  --polymer2: Rewrites urls in accordance with Polymer 2.x expectations, which applies the assetpath property of <dom-module> tags to the url() values in their style elements at runtime. ',
   '',
   'Examples:',
   '  The command',
@@ -77,6 +78,7 @@ var args = nopt(
     version: Boolean,
     abspath: String,
     exclude: [String, Array],
+    polymer2: Boolean,
     redirect: [String, Array],
     'add-import': [String, Array],
     'strip-exclude': [String, Array],
@@ -128,6 +130,7 @@ args.stripComments = args['strip-comments'];
 args.implicitStrip = !args['no-implicit-strip'];
 args.inlineScripts = args['inline-scripts'];
 args.inlineCss = args['inline-css'];
+args.polymer2 = args['polymer2'];
 
 var vulcanize = new vulcan(args);
 vulcanize.process(target, function(err, content) {

--- a/lib/pathresolver.js
+++ b/lib/pathresolver.js
@@ -30,7 +30,7 @@ PathResolver.prototype = {
     return href.search(constants.URL_TEMPLATE) >= 0;
   },
 
-  resolvePaths: function resolvePaths(importDoc, importUrl, mainDocUrl) {
+  resolvePaths: function resolvePaths(importDoc, importUrl, mainDocUrl, polymer2) {
     // rewrite URLs in element attributes
     var nodes = dom5.queryAll(importDoc, matchers.urlAttrs);
     var attrValue;
@@ -62,11 +62,14 @@ PathResolver.prototype = {
     }
 
     // rewrite URLs in stylesheets unless they're inside a <dom-module>
-    var styleNodes = dom5.queryAll(importDoc,
-        dom5.predicates.AND(
-            dom5.predicates.NOT(
-                dom5.predicates.parentMatches(dom5.predicates.hasTagName('dom-module'))),
-            matchers.CSS));
+    var styleNodes = polymer2 ?
+        dom5.queryAll(importDoc,
+            dom5.predicates.AND(
+                dom5.predicates.NOT(
+                    dom5.predicates.parentMatches(
+                        dom5.predicates.hasTagName('dom-module'))),
+                matchers.CSS)) :
+        dom5.queryAll(importDoc, matchers.CSS);
 
     for (i = 0, node; i < styleNodes.length; i++) {
       node = styleNodes[i];
@@ -118,7 +121,7 @@ PathResolver.prototype = {
   },
 
   // remove effects of <base>
-  acid: function acid(doc, docUrl) {
+  acid: function acid(doc, docUrl, polymer2) {
     var base = dom5.query(doc, matchers.base);
     if (base) {
       var baseUrl = dom5.getAttribute(base, 'href');
@@ -129,7 +132,7 @@ PathResolver.prototype = {
           baseUrl = baseUrl.slice(0, -1);
         }
         var docBaseUrl = url.resolve(docUrl, baseUrl + '/.index.html');
-        this.resolvePaths(doc, docBaseUrl, docUrl);
+        this.resolvePaths(doc, docBaseUrl, docUrl, polymer2);
       }
       if (baseTarget) {
         var elementsNeedTarget = dom5.queryAll(doc, matchers.targetMatcher);

--- a/lib/pathresolver.js
+++ b/lib/pathresolver.js
@@ -60,8 +60,14 @@ PathResolver.prototype = {
         }
       }
     }
-    // rewrite URLs in stylesheets
-    var styleNodes = dom5.queryAll(importDoc, matchers.CSS);
+
+    // rewrite URLs in stylesheets unless they're inside a <dom-module>
+    var styleNodes = dom5.queryAll(importDoc,
+        dom5.predicates.AND(
+            dom5.predicates.NOT(
+                dom5.predicates.parentMatches(dom5.predicates.hasTagName('dom-module'))),
+            matchers.CSS));
+
     for (i = 0, node; i < styleNodes.length; i++) {
       node = styleNodes[i];
       var styleText = dom5.getTextContent(node);

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -390,12 +390,10 @@ Vulcan.prototype = {
       // let the loader handle the requests
       return this.loader.request(uri).then(function(content) {
         if (content) {
-          content = this.pathResolver.rewriteURL(uri, href, content);
           if (media) {
             content = '@media ' + media + ' {' + content + '}';
           }
           var style = dom5.constructors.element('style');
-          dom5.setTextContent(style, '\n' + content + '\n');
 
           if (isPolymerExternalStyle) {
             // a polymer expternal style <link type="css" rel="import"> must be
@@ -403,6 +401,8 @@ Vulcan.prototype = {
             var ownerDomModule = dom5.nodeWalkPrior(tag, dom5.predicates.hasTagName('dom-module'));
             if (ownerDomModule) {
               var domTemplate = dom5.query(ownerDomModule, dom5.predicates.hasTagName('template'));
+              var assetpath = dom5.getAttribute(ownerDomModule, 'assetpath') || '';
+              content = this.pathResolver.rewriteURL(uri, url.resolve(href, assetpath), content);
               if (!domTemplate) {
                 // create a <template>, which has a fragment as childNodes[0]
                 domTemplate = dom5.constructors.element('template');
@@ -420,8 +420,10 @@ Vulcan.prototype = {
               lastPolymerExternalStyle = style;
             }
           } else {
+            content = this.pathResolver.rewriteURL(uri, href, content);
             dom5.replace(tag, style);
           }
+          dom5.setTextContent(style, '\n' + content + '\n');
         }
       }.bind(this));
     }.bind(this));

--- a/lib/vulcan.js
+++ b/lib/vulcan.js
@@ -105,6 +105,7 @@ var Vulcan = function Vulcan(opts) {
   this.inputUrl = String(opts.inputUrl) === opts.inputUrl ? opts.inputUrl : '';
   this.fsResolver = opts.fsResolver;
   this.redirects = Array.isArray(opts.redirects) ? opts.redirects : [];
+  this.polymer2 = opts.polymer2;
   if (opts.loader) {
     this.loader = opts.loader;
   } else {
@@ -246,7 +247,7 @@ Vulcan.prototype = {
       throw new Error(constants.OLD_POLYMER + ' File: ' + this.pathResolver.urlToPath(tree.href));
     }
     this.fixFakeExternalScripts(doc);
-    this.pathResolver.acid(doc, tree.href);
+    this.pathResolver.acid(doc, tree.href, this.polymer2);
     var moveTarget;
     if (isMainDoc) {
       // hide bodies of imports from rendering in main document
@@ -291,7 +292,7 @@ Vulcan.prototype = {
         var bodyFragment = dom5.constructors.fragment();
         var importDoc = this.flatten(im, mainDocUrl);
         // rewrite urls
-        this.pathResolver.resolvePaths(importDoc, im.href, tree.href);
+        this.pathResolver.resolvePaths(importDoc, im.href, tree.href, this.polymer2);
         var importHead = dom5.query(importDoc, matchers.head);
         var importBody = dom5.query(importDoc, matchers.body);
         // merge head and body tags for imports into main document
@@ -382,7 +383,7 @@ Vulcan.prototype = {
       var media = dom5.getAttribute(tag, 'media');
       var uri = url.resolve(href, src);
       var isPolymerExternalStyle = matchers.polymerExternalStyle(tag);
-
+      var polymer2 = this.polymer2;
       // let the loader handle the requests
       if (this.isExcludedHref(src)) {
         return Promise.resolve(true);
@@ -401,8 +402,12 @@ Vulcan.prototype = {
             var ownerDomModule = dom5.nodeWalkPrior(tag, dom5.predicates.hasTagName('dom-module'));
             if (ownerDomModule) {
               var domTemplate = dom5.query(ownerDomModule, dom5.predicates.hasTagName('template'));
-              var assetpath = dom5.getAttribute(ownerDomModule, 'assetpath') || '';
-              content = this.pathResolver.rewriteURL(uri, url.resolve(href, assetpath), content);
+              if (polymer2) {
+                var assetpath = dom5.getAttribute(ownerDomModule, 'assetpath') || '';
+                content = this.pathResolver.rewriteURL(uri, url.resolve(href, assetpath), content);
+              } else {
+                content = this.pathResolver.rewriteURL(uri, href, content);
+              }
               if (!domTemplate) {
                 // create a <template>, which has a fragment as childNodes[0]
                 domTemplate = dom5.constructors.element('template');

--- a/test/test.js
+++ b/test/test.js
@@ -151,7 +151,7 @@ suite('Path Resolver', function() {
       '<link rel="stylesheet" href="my-element/my-element.css">',
       '</head><body><dom-module id="my-element" assetpath="my-element/">',
       '<template>',
-      '<style>:host { background-image: url("my-element/background.svg"); }</style>',
+      '<style>:host { background-image: url(background.svg); }</style>',
       '<div style="position: absolute;"></div>',
       '</template>',
       '</dom-module>',
@@ -184,7 +184,7 @@ suite('Path Resolver', function() {
       '<link rel="stylesheet" href="my-element/zork/my-element.css">',
       '</head><body><dom-module id="my-element" assetpath="my-element/zork/">',
       '<template>',
-      '<style>:host { background-image: url("my-element/zork/background.svg"); }</style>',
+      '<style>:host { background-image: url(background.svg); }</style>',
       '</template>',
       '</dom-module>',
       '<script>Polymer({is: "my-element"})</script></body></html>'
@@ -217,7 +217,7 @@ suite('Path Resolver', function() {
       '<link rel="stylesheet" href="my-element/zork/my-element.css">',
       '</head><body><dom-module id="my-element" assetpath="my-element/zork/">',
       '<template>',
-      '<style>:host { background-image: url("my-element/zork/background.svg"); }</style>',
+      '<style>:host { background-image: url(background.svg); }</style>',
       '</template>',
       '</dom-module>',
       '<script>Polymer({is: "my-element"})</script></body></html>'

--- a/test/test.js
+++ b/test/test.js
@@ -146,7 +146,23 @@ suite('Path Resolver', function() {
       '<script>Polymer({is: "my-element"})</script>'
     ].join('\n');
 
-    var expected = [
+    var expectedPolymer1 = [
+      '<html><head><link rel="import" href="polymer/polymer.html">',
+      '<link rel="stylesheet" href="my-element/my-element.css">',
+      '</head><body><dom-module id="my-element" assetpath="my-element/">',
+      '<template>',
+      '<style>:host { background-image: url("my-element/background.svg"); }</style>',
+      '<div style="position: absolute;"></div>',
+      '</template>',
+      '</dom-module>',
+      '<script>Polymer({is: "my-element"})</script></body></html>'
+    ].join('\n');
+
+    var ast1 = parse(html);
+    pathresolver.resolvePaths(ast1, inputPath, outputPath);
+    assert.equal(serialize(ast1), expectedPolymer1, 'relative polymer 1 paths');
+
+    var expectedPolymer2 = [
       '<html><head><link rel="import" href="polymer/polymer.html">',
       '<link rel="stylesheet" href="my-element/my-element.css">',
       '</head><body><dom-module id="my-element" assetpath="my-element/">',
@@ -158,11 +174,9 @@ suite('Path Resolver', function() {
       '<script>Polymer({is: "my-element"})</script></body></html>'
     ].join('\n');
 
-    var ast = parse(html);
-    pathresolver.resolvePaths(ast, inputPath, outputPath);
-
-    var actual = serialize(ast);
-    assert.equal(actual, expected, 'relative');
+    var ast2 = parse(html);
+    pathresolver.resolvePaths(ast2, inputPath, outputPath, true);
+    assert.equal(serialize(ast2), expectedPolymer2, 'relative polymer 2 paths');
   });
 
   test('Resolve Paths with <base>', function() {
@@ -178,7 +192,24 @@ suite('Path Resolver', function() {
       '<script>Polymer({is: "my-element"})</script>'
     ].join('\n');
 
-    var expectedBase = [
+    var expectedBasePolymer1 = [
+      '<html><head>',
+      '<link rel="import" href="my-element/polymer/polymer.html">',
+      '<link rel="stylesheet" href="my-element/zork/my-element.css">',
+      '</head><body><dom-module id="my-element" assetpath="my-element/zork/">',
+      '<template>',
+      '<style>:host { background-image: url("my-element/zork/background.svg"); }</style>',
+      '</template>',
+      '</dom-module>',
+      '<script>Polymer({is: "my-element"})</script></body></html>'
+    ].join('\n');
+
+    var ast1 = parse(htmlBase);
+    pathresolver.acid(ast1, inputPath);
+    pathresolver.resolvePaths(ast1, inputPath, outputPath);
+    assert.equal(serialize(ast1), expectedBasePolymer1, 'base polymer 1');
+
+    var expectedBasePolymer2 = [
       '<html><head>',
       '<link rel="import" href="my-element/polymer/polymer.html">',
       '<link rel="stylesheet" href="my-element/zork/my-element.css">',
@@ -190,12 +221,10 @@ suite('Path Resolver', function() {
       '<script>Polymer({is: "my-element"})</script></body></html>'
     ].join('\n');
 
-    var ast = parse(htmlBase);
-    pathresolver.acid(ast, inputPath);
-    pathresolver.resolvePaths(ast, inputPath, outputPath);
-
-    var actual = serialize(ast);
-    assert.equal(actual, expectedBase, 'base');
+    var ast2 = parse(htmlBase);
+    pathresolver.acid(ast2, inputPath, true);
+    pathresolver.resolvePaths(ast2, inputPath, outputPath, true);
+    assert.equal(serialize(ast2), expectedBasePolymer2, 'base polymer 2');
   });
 
   test('Resolve Paths with <base> having a trailing /', function() {
@@ -211,7 +240,24 @@ suite('Path Resolver', function() {
       '<script>Polymer({is: "my-element"})</script>'
     ].join('\n');
 
-    var expectedBase = [
+    var expectedBasePolymer1 = [
+      '<html><head>',
+      '<link rel="import" href="my-element/polymer/polymer.html">',
+      '<link rel="stylesheet" href="my-element/zork/my-element.css">',
+      '</head><body><dom-module id="my-element" assetpath="my-element/zork/">',
+      '<template>',
+      '<style>:host { background-image: url("my-element/zork/background.svg"); }</style>',
+      '</template>',
+      '</dom-module>',
+      '<script>Polymer({is: "my-element"})</script></body></html>'
+    ].join('\n');
+
+    var ast1 = parse(htmlBase);
+    pathresolver.acid(ast1, inputPath);
+    pathresolver.resolvePaths(ast1, inputPath, outputPath);
+    assert.equal(serialize(ast1), expectedBasePolymer1, 'base polymer 1');
+
+    var expectedBasePolymer2 = [
       '<html><head>',
       '<link rel="import" href="my-element/polymer/polymer.html">',
       '<link rel="stylesheet" href="my-element/zork/my-element.css">',
@@ -223,12 +269,10 @@ suite('Path Resolver', function() {
       '<script>Polymer({is: "my-element"})</script></body></html>'
     ].join('\n');
 
-    var ast = parse(htmlBase);
-    pathresolver.acid(ast, inputPath);
-    pathresolver.resolvePaths(ast, inputPath, outputPath);
-
-    var actual = serialize(ast);
-    assert.equal(actual, expectedBase, 'base');
+    var ast2 = parse(htmlBase);
+    pathresolver.acid(ast2, inputPath, true);
+    pathresolver.resolvePaths(ast2, inputPath, outputPath, true);
+    assert.equal(serialize(ast2), expectedBasePolymer2, 'base polymer 2');
   });
 
   test('Resolve <base target>', function() {


### PR DESCRIPTION
**TO THE REVIEWER: PLEASE NOTE APPVEYOR IS FAILING BECAUSE THIS IS ON THE 1.X BRANCH AKA VULCANIZE WHICH IS NOT SUPPORTED ON APPVERYOR**

- Added `--polymer2` flag that changes some of the rewriting behaviors to support the fact that Polymer 2.x honors the `assetpath` of `<dom-module>` when interpreting style urls:
  - Disables rewriting urls in inlined html imports containing `<style>` tags inside `<dom-module>` containers.
  - Include consideration of container `<dom-module>` `assetpath` property when rewriting urls inside inlined style imports.
- [x] CHANGELOG.md has been updated
- Opportunistically added a CHANGELOG item for previously merged fix to reverse-ordering of inlined style imports from previous merged commit.