### PR TITLE
Make rewriteUrlsInTemplates effect <style> tag rewriting.

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -222,9 +222,9 @@ export class Bundler {
     }
     if (this.enableCssInlining) {
       await this._inlineStylesheetLinks(
-          document, ast, docBundle, this.excludes);
+          document, ast, docBundle, this.excludes, this.rewriteUrlsInTemplates);
       await this._inlineStylesheetImports(
-          document, ast, docBundle, this.excludes);
+          document, ast, docBundle, this.excludes, this.rewriteUrlsInTemplates);
     }
 
     if (this.stripComments) {
@@ -439,13 +439,19 @@ export class Bundler {
       document: Document,
       ast: ASTNode,
       bundle: AssignedBundle,
-      excludes: string[]) {
+      excludes: string[],
+      rewriteUrlsInTemplates: boolean) {
     const cssImports = dom5.queryAll(ast, matchers.stylesheetImport);
     let lastInlined: (ASTNode|undefined);
 
     for (const cssLink of cssImports) {
       const style = await importUtils.inlineStylesheet(
-          this.analyzer, document, cssLink, bundle, excludes);
+          this.analyzer,
+          document,
+          cssLink,
+          bundle,
+          excludes,
+          rewriteUrlsInTemplates);
       if (style) {
         this._moveDomModuleStyleIntoTemplate(style, lastInlined);
         lastInlined = style;
@@ -462,11 +468,17 @@ export class Bundler {
       document: Document,
       ast: ASTNode,
       bundle: AssignedBundle,
-      excludes?: string[]) {
+      excludes?: string[],
+      rewriteUrlsInTemplates?: boolean) {
     const cssLinks = dom5.queryAll(ast, matchers.externalStyle);
     for (const cssLink of cssLinks) {
       await importUtils.inlineStylesheet(
-          this.analyzer, document, cssLink, bundle, excludes);
+          this.analyzer,
+          document,
+          cssLink,
+          bundle,
+          excludes,
+          rewriteUrlsInTemplates);
     }
   }
 

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -671,6 +671,18 @@ suite('Bundler', () => {
       assert.match(dom5.getTextContent(style), /url\("styles\/unicorn.png"\)/);
     });
 
+    test('Inlining ignores assetpath if rewriteUrlsInTemplates', async () => {
+      const doc = await bundle(
+          'test/html/style-rewriting.html',
+          {inlineCss: true, rewriteUrlsInTemplates: true});
+      const style = dom5.query(
+          doc, matchers.styleMatcher, dom5.childNodesIncludeTemplate)!;
+      assert.isNotNull(style);
+      assert.match(
+          dom5.getTextContent(style),
+          /url\("style-rewriting\/styles\/unicorn.png"\)/);
+    });
+
     test('Inlined styles have proper paths', async () => {
       const doc = await bundle('test/html/inline-styles.html', options);
       const styles = dom5.queryAll(

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -130,7 +130,7 @@ suite('import-utils', () => {
           <link rel="stylesheet" href="my-element/my-element.css">
           <dom-module id="my-element" assetpath="my-element/">
           <template>
-          <style>:host { background-image: url(background.svg); }</style>
+          <style>:host { background-image: url("my-element/background.svg"); }</style>
           <div style="background-image: url(&quot;my-element/background.svg&quot;)"></div>
           </template>
           <script>Polymer({is: "my-element"})</script>


### PR DESCRIPTION
 - This is a backwards-compatible feature allows working with polymer 1.x from bundler now that it is defaulting to supporting relative paths for polymer 2.x style elements.
 - Don't merge this until bundler 3.0
 - [ ] CHANGELOG.md has been updated
