### PR TITLE
Fix invalid url-rewriting in inlined templated element style tags, with backwards-compatible flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- BREAKING: The following changes support polymer 2.x behaviors but will break some Polymer 1.x projects which may rely on the rewriting of relative urls within style tags.  For those projects, set the `rewriteUrlsInTemplates` option to `true` or use `--rewriteUrlsInTemplates` at command-line.
+- BREAKING: The following changes support polymer 2.x, but will break some Polymer 1.x projects which may rely on the rewriting of relative urls within style tags.  For those projects, set the `rewriteUrlsInTemplates` option to `true` or use `--rewriteUrlsInTemplates` at command-line.
   - Fixed [issue #579](https://github.com/Polymer/polymer-bundler/issues/579) where `url()` values inside `<style>` tags inside of `<dom-module>` tags of inlined html imports were rewritten without consideration of the module's `assetpath` property.
   - Fixed issue when stylesheet imports are inlined inside of a `<dom-module>` the url resolution now takes into consideration the `assetpath`.
 <!-- Add new, unreleased changes here. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- BREAKING: The following changes support polymer 2.x behaviors but will break some Polymer 1.x projects which may rely on the rewriting of relative urls within style tags.  For those projects, set the `rewriteUrlsInTemplates` option to `true` or use `--rewriteUrlsInTemplates` at command-line.
+  - Fixed [issue #579](https://github.com/Polymer/polymer-bundler/issues/579) where `url()` values inside `<style>` tags inside of `<dom-module>` tags of inlined html imports were rewritten without consideration of the module's `assetpath` property.
+  - Fixed issue when stylesheet imports are inlined inside of a `<dom-module>` the url resolution now takes into consideration the `assetpath`.
 <!-- Add new, unreleased changes here. -->
 
 ## 2.3.1 - 2017-07-13

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -222,9 +222,9 @@ export class Bundler {
     }
     if (this.enableCssInlining) {
       await this._inlineStylesheetLinks(
-          document, ast, docBundle, this.excludes);
+          document, ast, docBundle, this.excludes, this.rewriteUrlsInTemplates);
       await this._inlineStylesheetImports(
-          document, ast, docBundle, this.excludes);
+          document, ast, docBundle, this.excludes, this.rewriteUrlsInTemplates);
     }
 
     if (this.stripComments) {
@@ -439,13 +439,19 @@ export class Bundler {
       document: Document,
       ast: ASTNode,
       bundle: AssignedBundle,
-      excludes: string[]) {
+      excludes: string[],
+      rewriteUrlsInTemplates: boolean) {
     const cssImports = dom5.queryAll(ast, matchers.stylesheetImport);
     let lastInlined: (ASTNode|undefined);
 
     for (const cssLink of cssImports) {
       const style = await importUtils.inlineStylesheet(
-          this.analyzer, document, cssLink, bundle, excludes);
+          this.analyzer,
+          document,
+          cssLink,
+          bundle,
+          excludes,
+          rewriteUrlsInTemplates);
       if (style) {
         this._moveDomModuleStyleIntoTemplate(style, lastInlined);
         lastInlined = style;
@@ -462,11 +468,17 @@ export class Bundler {
       document: Document,
       ast: ASTNode,
       bundle: AssignedBundle,
-      excludes?: string[]) {
+      excludes?: string[],
+      rewriteUrlsInTemplates?: boolean) {
     const cssLinks = dom5.queryAll(ast, matchers.externalStyle);
     for (const cssLink of cssLinks) {
       await importUtils.inlineStylesheet(
-          this.analyzer, document, cssLink, bundle, excludes);
+          this.analyzer,
+          document,
+          cssLink,
+          bundle,
+          excludes,
+          rewriteUrlsInTemplates);
     }
   }
 

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -269,10 +269,24 @@ export async function inlineStylesheet(
   }
   const stylesheetContent = stylesheetImport.document.parsedDocument.contents;
   const media = dom5.getAttribute(cssLink, 'media');
-  const resolvedStylesheetContent =
-      rewriteCssTextBaseUrl(stylesheetContent, resolvedImportUrl, document.url);
-  const styleNode = dom5.constructors.element('style');
 
+  let newBaseUrl = document.url;
+
+  // If the css link we are about to inline is inside of a dom-module, the new
+  // base url must be calculated using the assetpath of the dom-module if
+  // present, since Polymer will honor assetpath when resolving urls in
+  // `<style>` tags, even inside of `<template>` tags.
+  const parentDomModule =
+      findAncestor(cssLink, dom5.predicates.hasTagName('dom-module'));
+  if (parentDomModule && dom5.hasAttribute(parentDomModule, 'assetpath')) {
+    const assetPath = dom5.getAttribute(parentDomModule, 'assetpath') || '';
+    if (assetPath) {
+      newBaseUrl = urlLib.resolve(newBaseUrl, assetPath);
+    }
+  }
+  const resolvedStylesheetContent =
+      rewriteCssTextBaseUrl(stylesheetContent, resolvedImportUrl, newBaseUrl);
+  const styleNode = dom5.constructors.element('style');
   if (media) {
     dom5.setAttribute(styleNode, 'media', media);
   }
@@ -282,7 +296,6 @@ export async function inlineStylesheet(
 
   // Record that the inlining took place.
   docBundle.bundle.inlinedStyles.add(resolvedImportUrl);
-
   return styleNode;
 }
 
@@ -330,7 +343,7 @@ export function rewriteAstBaseUrl(
     rewriteUrlsInTemplates?: boolean) {
   rewriteElementAttrsBaseUrl(
       ast, oldBaseUrl, newBaseUrl, rewriteUrlsInTemplates);
-  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl);
+  rewriteStyleTagsBaseUrl(ast, oldBaseUrl, newBaseUrl, rewriteUrlsInTemplates);
   setDomModuleAssetpaths(ast, oldBaseUrl, newBaseUrl);
 }
 
@@ -367,6 +380,25 @@ export async function addOrUpdateSourcemapsForInlineScripts(
 
   return Promise.all(promises);
 }
+
+/**
+ * Walk the ancestor nodes from parentNode up to document root, returning the
+ * first one matching the predicate function.
+ */
+function findAncestor(ast: ASTNode, predicate: dom5.Predicate): ASTNode|
+    undefined {
+  // The visited set protects us against circular references.
+  const visited = new Set();
+  while (ast.parentNode && !visited.has(ast.parentNode)) {
+    if (predicate(ast.parentNode)) {
+      return ast.parentNode;
+    }
+    visited.add(ast.parentNode);
+    ast = ast.parentNode;
+  }
+  return undefined;
+}
+
 
 /**
  * Simple utility function used to find an item in a set with a predicate
@@ -434,9 +466,32 @@ function rewriteElementAttrsBaseUrl(
  * on the relationship of the old base url to the new base url.
  */
 function rewriteStyleTagsBaseUrl(
-    ast: ASTNode, oldBaseUrl: UrlString, newBaseUrl: UrlString) {
-  const styleNodes = dom5.queryAll(
-      ast, matchers.styleMatcher, undefined, dom5.childNodesIncludeTemplate);
+    ast: ASTNode,
+    oldBaseUrl: UrlString,
+    newBaseUrl: UrlString,
+    rewriteUrlsInTemplates: boolean = false) {
+  const childNodesOption = rewriteUrlsInTemplates ?
+      dom5.childNodesIncludeTemplate :
+      dom5.defaultChildNodes;
+
+  // If `rewriteUrlsInTemplates` is `true`, include `<style>` tags that are
+  // inside `<template>`.
+  const styleNodes =
+      dom5.queryAll(ast, matchers.styleMatcher, undefined, childNodesOption);
+
+  // However, if a `<style>` tag is anywhere inside a `<dom-module>` tag, then
+  // it should not have its urls rewritten.
+  for (const domModule of dom5.queryAll(
+           ast, dom5.predicates.hasTagName('dom-module'))) {
+    for (const styleNode of dom5.queryAll(
+             domModule, matchers.styleMatcher, undefined, childNodesOption)) {
+      const styleNodeIndex = styleNodes.indexOf(styleNode);
+      if (styleNodeIndex > -1) {
+        styleNodes.splice(styleNodeIndex, 1);
+      }
+    }
+  }
+
   for (const node of styleNodes) {
     let styleText = dom5.getTextContent(node);
     styleText = rewriteCssTextBaseUrl(styleText, oldBaseUrl, newBaseUrl);

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -671,6 +671,18 @@ suite('Bundler', () => {
       assert.match(dom5.getTextContent(style), /url\("styles\/unicorn.png"\)/);
     });
 
+    test('Inlining ignores assetpath if rewriteUrlsInTemplates', async () => {
+      const doc = await bundle(
+          'test/html/style-rewriting.html',
+          {inlineCss: true, rewriteUrlsInTemplates: true});
+      const style = dom5.query(
+          doc, matchers.styleMatcher, dom5.childNodesIncludeTemplate)!;
+      assert.isNotNull(style);
+      assert.match(
+          dom5.getTextContent(style),
+          /url\("style-rewriting\/styles\/unicorn.png"\)/);
+    });
+
     test('Inlined styles have proper paths', async () => {
       const doc = await bundle('test/html/inline-styles.html', options);
       const styles = dom5.queryAll(

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -650,14 +650,25 @@ suite('Bundler', () => {
           doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(links.length, 0);
       assert.equal(styles.length, 3);
+      assert.match(dom5.getTextContent(styles[0]), /regular-style/);
+      assert.match(dom5.getTextContent(styles[1]), /simple-style/);
+      assert.match(dom5.getTextContent(styles[2]), /import-linked-style/);
+
+      // Verify the inlined url() values in the stylesheet are not rewritten
+      // to use the "imports/" prefix, since the stylesheet is inside a
+      // `<dom-module>` with an assetpath that defines the base url as
+      // "imports/".
       assert.match(
-          dom5.getTextContent(styles[0]), /regular-style/, 'regular-style.css');
-      assert.match(
-          dom5.getTextContent(styles[1]), /simple-style/, 'simple-style.css');
-      assert.match(
-          dom5.getTextContent(styles[2]),
-          /import-linked-style/,
-          'import-linked-style.css');
+          dom5.getTextContent(styles[1]), /url\("assets\/platform\.png"\)/);
+    });
+
+    test('Inlined styles observe containing dom-module assetpath', async () => {
+      const doc =
+          await bundle('test/html/style-rewriting.html', {inlineCss: true});
+      const style = dom5.query(
+          doc, matchers.styleMatcher, dom5.childNodesIncludeTemplate)!;
+      assert.isNotNull(style);
+      assert.match(dom5.getTextContent(style), /url\("styles\/unicorn.png"\)/);
     });
 
     test('Inlined styles have proper paths', async () => {

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -130,7 +130,7 @@ suite('import-utils', () => {
           <link rel="stylesheet" href="my-element/my-element.css">
           <dom-module id="my-element" assetpath="my-element/">
           <template>
-          <style>:host { background-image: url(background.svg); }</style>
+          <style>:host { background-image: url("my-element/background.svg"); }</style>
           <div style="background-image: url(&quot;my-element/background.svg&quot;)"></div>
           </template>
           <script>Polymer({is: "my-element"})</script>

--- a/src/test/import-utils_test.ts
+++ b/src/test/import-utils_test.ts
@@ -74,10 +74,14 @@ suite('import-utils', () => {
           <template>
           <img src="neato.gif">
           <style>:host { background-image: url(background.svg); }</style>
-          <div style="position: absolute;"></div>
+          <div style="background-image: url(background.svg)"></div>
           </template>
-          </dom-module>
           <script>Polymer({is: "my-element"})</script>
+          </dom-module>
+          <template is="dom-bind">
+          <style>.outside-dom-module { background-image: url(outside-dom-module.png); }</style>
+          </template>
+          <style>.outside-template { background-image: url(outside-template.png); }</style>
         `;
 
         const expected = `
@@ -86,11 +90,15 @@ suite('import-utils', () => {
           <dom-module id="my-element" assetpath="my-element/">
           <template>
           <img src="neato.gif">
-          <style>:host { background-image: url("my-element/background.svg"); }</style>
-          <div style="position: absolute;"></div>
+          <style>:host { background-image: url(background.svg); }</style>
+          <div style="background-image: url(background.svg)"></div>
           </template>
-          </dom-module>
           <script>Polymer({is: "my-element"})</script>
+          </dom-module>
+          <template is="dom-bind">
+          <style>.outside-dom-module { background-image: url(outside-dom-module.png); }</style>
+          </template>
+          <style>.outside-template { background-image: url("my-element/outside-template.png"); }</style>
         `;
 
         const ast = astUtils.parse(html);
@@ -107,10 +115,14 @@ suite('import-utils', () => {
           <dom-module id="my-element">
           <template>
           <style>:host { background-image: url(background.svg); }</style>
-          <div style="position: absolute;"></div>
+          <div style="background-image: url(background.svg)"></div>
           </template>
-          </dom-module>
           <script>Polymer({is: "my-element"})</script>
+          </dom-module>
+          <template is="dom-bind">
+          <style>.something { background-image: url(something.png); }</style>
+          </template>
+          <style>.outside-template { background-image: url(outside-template.png); }</style>
         `;
 
         const expected = `
@@ -118,11 +130,15 @@ suite('import-utils', () => {
           <link rel="stylesheet" href="my-element/my-element.css">
           <dom-module id="my-element" assetpath="my-element/">
           <template>
-          <style>:host { background-image: url("my-element/background.svg"); }</style>
-          <div style="position: absolute;"></div>
+          <style>:host { background-image: url(background.svg); }</style>
+          <div style="background-image: url(&quot;my-element/background.svg&quot;)"></div>
           </template>
-          </dom-module>
           <script>Polymer({is: "my-element"})</script>
+          </dom-module>
+          <template is="dom-bind">
+          <style>.something { background-image: url("my-element/something.png"); }</style>
+          </template>
+          <style>.outside-template { background-image: url("my-element/outside-template.png"); }</style>
         `;
 
         const ast = astUtils.parse(html);
@@ -168,14 +184,14 @@ suite('import-utils', () => {
         <link rel="stylesheet" href="components/my-element/my-element.css">
         <dom-module id="my-element" assetpath="components/my-element/">
         <template>
-        <style>:host { background-image: url("components/my-element/background.svg"); }</style>
-        <img src="components/my-element/bloop.gif">
+        <style>:host { background-image: url(background.svg); }</style>
+        <img src="bloop.gif">
         </template>
         </dom-module>
         <script>Polymer({is: "my-element"})</script>`;
 
       const ast = astUtils.parse(htmlBase);
-      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url', true);
+      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url');
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(expectedBase), 'base');
@@ -202,15 +218,15 @@ suite('import-utils', () => {
         <link rel="stylesheet" href="components/my-element.css">
         <dom-module id="my-element" assetpath="components/">
         <template>
-        <style>:host { background-image: url("components/background.svg"); }</style>
-        <img src="components/bloop.gif">
+        <style>:host { background-image: url(background.svg); }</style>
+        <img src="bloop.gif">
         </template>
         </dom-module>
         <script>Polymer({is: "my-element"})</script>
       `;
 
       const ast = astUtils.parse(htmlBase);
-      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url', true);
+      importUtils.rewriteAstToEmulateBaseTag(ast, 'the/doc/url');
 
       const actual = parse5.serialize(ast);
       assert.deepEqual(stripSpace(actual), stripSpace(expectedBase), 'base');

--- a/src/test/url-utils_test.ts
+++ b/src/test/url-utils_test.ts
@@ -115,6 +115,10 @@ suite('URL Utils', () => {
           '../../foo.html',
           'neither has ^/');
     });
+
+    test('Rewrite paths when new base url has trailing slash', () => {
+      testRewrite('pic.png', 'foo/bar/baz.html', 'foo/', 'bar/pic.png');
+    });
   });
 
   suite('Relative URL calculations', () => {

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -117,7 +117,10 @@ export function rewriteHrefBaseUrl(
   const parsedTo = url.parse(absUrl);
   if (parsedFrom.protocol === parsedTo.protocol &&
       parsedFrom.host === parsedTo.host) {
-    let dirFrom = path.posix.dirname(parsedFrom.pathname || '');
+    let dirFrom = path.posix.dirname(
+        // Have to append a '_' to the path because path.posix.dirname('foo/')
+        // returns '.' instead of 'foo'.
+        parsedFrom.pathname ? parsedFrom.pathname + '_' : '');
     let pathTo = parsedTo.pathname || '';
     if (isAbsolutePath(oldBaseUrl) || isAbsolutePath(newBaseUrl)) {
       dirFrom = makeAbsolutePath(dirFrom);

--- a/test/html/imports/simple-style.css
+++ b/test/html/imports/simple-style.css
@@ -8,8 +8,8 @@ Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 */
 .from-simple-style { color: blue; }
-:host([type="platform"]) { background-color: red; }
-:host([type="core"]) { background-color: red; }
-:host([type="elements"]) { background-color: red; }
+:host([type="platform"]) { background-image: url('assets/platform.png'); }
+:host([type="core"]) { background-color: url('assets/core.png'); }
+:host([type="elements"]) { background-color: url('assets/elements.png'); }
 polyfill-next-selector { content: ':host header'; }
 polyfill-next-selector { content: 'I WIN'; }

--- a/test/html/style-rewriting.html
+++ b/test/html/style-rewriting.html
@@ -1,0 +1,1 @@
+<link rel="import" href="style-rewriting/element-with-style-import.html">

--- a/test/html/style-rewriting/element-with-style-import.html
+++ b/test/html/style-rewriting/element-with-style-import.html
@@ -1,0 +1,9 @@
+<dom-module id="element-with-style-import">
+  <link rel="import" href="styles/imported-style.css" type="css">
+  <template>
+    <div class="unicorn"></div>
+  </template>
+  <script>
+    Polymer({ is: 'element-with-style-import' });
+  </script>
+</dom-module>

--- a/test/html/style-rewriting/styles/imported-style.css
+++ b/test/html/style-rewriting/styles/imported-style.css
@@ -1,0 +1,1 @@
+.unicorn { background-image: url(unicorn.png); }


### PR DESCRIPTION
- BREAKING: The following changes support polymer 2.x but will break *some* Polymer 1.x projects which may rely on the rewriting of relative urls within style tags.  For those projects, set the `rewriteUrlsInTemplates` option to `true` or use `--rewriteUrlsInTemplates` at command-line.
  - Fixed [issue #579](https://github.com/Polymer/polymer-bundler/issues/579) where `url()` values inside `<style>` tags inside of `<dom-module>` tags of inlined html imports were rewritten without consideration of the module's `assetpath` property.
  - Fixed issue when stylesheet imports are inlined inside of a `<dom-module>` the url resolution now takes into consideration the `assetpath`.
- [x] CHANGELOG.md has been updated
