### PR TITLE
Fix --manifest-out file set for merged bundle strategy cases (like shell).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+- Fixed [issue #592](https://github.com/Polymer/polymer-bundler/issues/592) where the `--manifest-out` option of `bin/polymer-bundler` did not correctly include the basis document of shell files in inlined content list.
 <!-- Add new, unreleased changes here. -->
 
 ## 3.0.0 - 2017-07-14

--- a/src/bin/polymer-bundler.ts
+++ b/src/bin/polymer-bundler.ts
@@ -241,29 +241,18 @@ function bundleManifestToJson(manifest: BundleManifest): JsonManifest {
   const json: JsonManifest = {};
   const missingImports: Set<string> = new Set();
   for (const [url, bundle] of manifest.bundles) {
-    json[url] = [
+    json[url] = [...new Set([
+      // `files` and `inlinedHtmlImports` will be partially duplicative, but use
+      // of both ensures the basis document for a file is included since there
+      // is no other specific property that currently expresses it.
+      ...bundle.files,
       ...bundle.inlinedHtmlImports,
       ...bundle.inlinedScripts,
       ...bundle.inlinedStyles
-    ];
+    ])];
 
     for (const missingImport of bundle.missingImports) {
       missingImports.add(missingImport);
-    }
-
-    if (bundle.entrypoints.size > 1) {
-      continue;
-    }
-
-    // Include the entrypoint in the manifest where bundle has just one
-    // entrypoint, since we know this is the document that was the basis for the
-    // bundle.
-    // TODO(usergenic): Extend Bundle with a basis document property to provide
-    // a more conventional means to get at this.
-    for (const entrypoint of bundle.entrypoints) {
-      if (!bundle.inlinedHtmlImports.has(entrypoint)) {
-        json[url].unshift(entrypoint);
-      }
     }
   }
   if (missingImports.size > 0) {

--- a/src/test/polymer-bundler_test.ts
+++ b/src/test/polymer-bundler_test.ts
@@ -118,6 +118,41 @@ suite('polymer-bundler CLI', () => {
         ]
       });
     });
+
+    test('manifest includes all files including basis', async () => {
+      const projectRoot = path.resolve(__dirname, '../../test/html/imports');
+      const tempdir = fs.mkdtempSync(path.join(os.tmpdir(), ' ').trim());
+      const manifestPath = path.join(tempdir, 'bundle-manifest.json');
+      execSync(
+          `cd ${projectRoot} && ` +
+          `node ${cliPath} --inline-scripts --inline-css ` +
+          `--in-html eagerly-importing-a-fragment.html ` +
+          `--in-html importing-fragments/fragment-a.html ` +
+          `--in-html importing-fragments/fragment-b.html ` +
+          `--in-html importing-fragments/shell.html ` +
+          `--shell importing-fragments/shell.html ` +
+          `--out-dir ${tempdir}/bundled/ ` +
+          `--manifest-out ${manifestPath}`)
+          .toString();
+      const manifestJson = fs.readFileSync(manifestPath).toString();
+      const manifest = JSON.parse(manifestJson);
+      assert.deepEqual(manifest, {
+        'eagerly-importing-a-fragment.html': [
+          'eagerly-importing-a-fragment.html',
+        ],
+        'importing-fragments/fragment-a.html': [
+          'importing-fragments/fragment-a.html',
+        ],
+        'importing-fragments/fragment-b.html': [
+          'importing-fragments/fragment-b.html',
+        ],
+        'importing-fragments/shell.html': [
+          'importing-fragments/shell.html',
+          'importing-fragments/shared-util.html',
+        ],
+      });
+
+    });
   });
 
   suite('--redirect', () => {


### PR DESCRIPTION
- Fixed [issue #592](https://github.com/Polymer/polymer-bundler/issues/592) where the `--manifest-out` option of `bin/polymer-bundler` did not correctly include the basis document of shell files in inlined content list.
- [x] CHANGELOG.md has been updated
