### PR TITLE
Inline external stylesheet links inside templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased changes here. -->
+- Fixed [issue #600](https://github.com/Polymer/polymer-bundler/issues/600) where `<link rel=stylesheet>` inside a `<template>` was not inlined.  If you want to exclude a specific stylesheet from inlining, you can add its path the the `excludes` option (or `--exclude` on command line).
 
 ## 3.0.1 - 2017-07-17
 - Fixed [issue #592](https://github.com/Polymer/polymer-bundler/issues/592) where the `--manifest-out` option of `bin/polymer-bundler` did not correctly include the basis document of shell files in inlined content list.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,17 @@
       "dev": true
     },
     "@types/chai-subset": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.0.tgz",
-      "integrity": "sha1-dM7M7zsvwtpzkbcT3rcv6afl94I=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
       "requires": {
-        "@types/chai": "4.0.1"
+        "@types/chai": "4.0.4"
       },
       "dependencies": {
         "@types/chai": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.1.tgz",
-          "integrity": "sha512-DWrdkraJO+KvBB7+Jc6AuDd2+fwV6Z9iK8cqEEoYpcurYrH7GiUZmwjFuQIIWj5HhFz6NsSxdN72YMIHT7Fy2Q=="
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.4.tgz",
+          "integrity": "sha512-cvU0HomQ7/aGDQJZsbtJXqBQ7w4J4TqLB0Z/h8mKrpRjfeZEvTbygkfJEb7fWdmwpIeDeFmIVwAEqS0OYuUv3Q=="
         }
       }
     },
@@ -50,34 +50,42 @@
       "resolved": "https://registry.npmjs.org/@types/escodegen/-/escodegen-0.0.2.tgz",
       "integrity": "sha1-fOpBqyQukQ6xD2WuGK66RZ1ms18="
     },
+    "@types/estraverse": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-0.0.6.tgz",
+      "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
+      "requires": {
+        "@types/estree": "0.0.37"
+      }
+    },
     "@types/estree": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.34.tgz",
-      "integrity": "sha1-qnr2mjqRkiFx7kEbPJ2Pa+tK8yE="
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.37.tgz",
+      "integrity": "sha512-1IT6vNpmU9w18P3v6mN9idv18z5KPVTi4t7+rU9VLnkxo0LCam8IXy/eSVzOaQ1Wpabra2cN3A8K/SliPK/Suw=="
     },
     "@types/mocha": {
-      "version": "2.2.41",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.41.tgz",
-      "integrity": "sha1-4nzwgXFT658nE7LT9saPHhw8pgg=",
+      "version": "2.2.43",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
+      "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
       "dev": true
     },
     "@types/node": {
-      "version": "6.0.81",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.81.tgz",
-      "integrity": "sha512-KdtXOH8l9O2wwOOX+swjbFx+YW/RJFfI14o6S50+Zy79FK1WFGkzFdDsiuNjrG5L6FaBSKpKzSpWgTvXurbbYg=="
+      "version": "6.0.88",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+      "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ=="
     },
     "@types/parse5": {
       "version": "2.2.34",
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
-        "@types/node": "6.0.81"
+        "@types/node": "6.0.88"
       }
     },
     "@types/source-map": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.0.tgz",
-      "integrity": "sha1-3TS72OMv5OdPLj2KwH+KpbRaR6w=",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.1.tgz",
+      "integrity": "sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA==",
       "dev": true
     },
     "abbrev": {
@@ -87,9 +95,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -126,11 +134,11 @@
         "json-stable-stringify": "1.0.1"
       }
     },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "optional": true
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
     },
     "ansi-align": {
       "version": "1.1.0",
@@ -323,9 +331,9 @@
       }
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "clang-format": {
@@ -336,7 +344,7 @@
       "requires": {
         "async": "1.5.2",
         "glob": "7.1.2",
-        "resolve": "1.3.3"
+        "resolve": "1.4.0"
       }
     },
     "cli-boxes": {
@@ -365,9 +373,9 @@
       }
     },
     "cli-width": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
-      "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
     "clone": {
@@ -476,9 +484,9 @@
       }
     },
     "core-js": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -506,13 +514,13 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.30"
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -574,7 +582,7 @@
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       }
     },
     "delayed-stream": {
@@ -613,7 +621,7 @@
       "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
       "requires": {
         "@types/clone": "0.1.30",
-        "@types/node": "6.0.81",
+        "@types/node": "6.0.88",
         "@types/parse5": "2.2.34",
         "clone": "2.1.1",
         "parse5": "2.2.3"
@@ -653,9 +661,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.24",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
-      "integrity": "sha1-pVh3yZJLwMjZvTwsvhdJWsFwmxQ=",
+      "version": "0.10.30",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.30.tgz",
+      "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.1",
@@ -669,7 +677,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.30",
         "es6-symbol": "3.1.1"
       }
     },
@@ -680,7 +688,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -694,7 +702,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -707,7 +715,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.30"
       }
     },
     "es6-weak-map": {
@@ -717,7 +725,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24",
+        "es5-ext": "0.10.30",
         "es6-iterator": "2.0.1",
         "es6-symbol": "3.1.1"
       }
@@ -728,31 +736,15 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
+        "source-map": "0.5.7"
       }
     },
     "escope": {
@@ -775,22 +767,22 @@
       "requires": {
         "chalk": "1.1.3",
         "concat-stream": "1.6.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "doctrine": "1.5.0",
         "es6-map": "0.1.5",
         "escope": "3.6.0",
-        "espree": "3.4.3",
+        "espree": "3.5.1",
         "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "file-entry-cache": "1.3.1",
         "glob": "7.1.2",
         "globals": "9.18.0",
-        "ignore": "3.3.3",
+        "ignore": "3.3.5",
         "imurmurhash": "0.1.4",
         "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.0",
+        "is-my-json-valid": "2.16.1",
         "is-resolvable": "1.0.0",
-        "js-yaml": "3.9.0",
+        "js-yaml": "3.10.0",
         "json-stable-stringify": "1.0.1",
         "levn": "0.3.0",
         "lodash": "4.17.4",
@@ -821,18 +813,18 @@
       }
     },
     "espree": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-      "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "esrecurse": {
       "version": "4.2.0",
@@ -861,7 +853,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.24"
+        "es5-ext": "0.10.30"
       }
     },
     "exit-hook": {
@@ -993,21 +985,21 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
       }
     },
     "form-data": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.2.0.tgz",
-      "integrity": "sha1-ml47kpX5gLJiPPZPojixTOvKcHs=",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+      "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.17"
       }
     },
     "fs.realpath": {
@@ -1017,9 +1009,9 @@
       "dev": true
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
@@ -1112,7 +1104,7 @@
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
       "dev": true,
       "requires": {
-        "function-bind": "1.1.0"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -1136,7 +1128,7 @@
       "dev": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1"
       }
     },
@@ -1147,14 +1139,14 @@
       "dev": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1"
       }
     },
     "ignore": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
-      "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
       "dev": true
     },
     "imurmurhash": {
@@ -1195,7 +1187,7 @@
         "ansi-regex": "2.1.1",
         "chalk": "1.1.3",
         "cli-cursor": "1.0.2",
-        "cli-width": "2.1.0",
+        "cli-width": "2.2.0",
         "figures": "1.7.0",
         "lodash": "4.17.4",
         "readline2": "1.0.1",
@@ -1250,9 +1242,9 @@
       }
     },
     "is-my-json-valid": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
+      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -1372,13 +1364,10 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isobject": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "jade": {
       "version": "0.26.3",
@@ -1411,9 +1400,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-      "integrity": "sha512-0LoUNELX4S+iofCT8f4uEHIiRBR+c2AINyC8qRWfC6QNruLtxVZRJaPcu/xwMgFIgDxF25tGHaDjvxzJCNE9yw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -1450,9 +1439,9 @@
       "dev": true
     },
     "jsonschema": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.1.1.tgz",
-      "integrity": "sha1-PO3o4+QR03eHLu+8n98mODy8Ptk="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.0.tgz",
+      "integrity": "sha512-XDJApzBauMg0TinJNP4iVcJl99PQ4JbWKK7nwzpOIkAOVveDKgh/2xm41T3x7Spu4PWMhnnQpNJmUSIUgl6sKg=="
     },
     "latest-version": {
       "version": "2.0.0",
@@ -1543,18 +1532,18 @@
       }
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "1.30.0"
       }
     },
     "minimatch": {
@@ -1686,12 +1675,12 @@
       "dev": true
     },
     "object.pick": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.2.0.tgz",
-      "integrity": "sha1-tTkr7peC2m2ft9avr1OXefEjTCs=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "2.1.0"
+        "isobject": "3.0.1"
       }
     },
     "once": {
@@ -1771,13 +1760,13 @@
         "got": "5.7.1",
         "registry-auth-token": "3.3.1",
         "registry-url": "3.1.0",
-        "semver": "5.3.0"
+        "semver": "5.4.1"
       },
       "dependencies": {
         "semver": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
           "dev": true
         }
       }
@@ -1842,30 +1831,31 @@
       "dev": true
     },
     "polymer-analyzer": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.2.1.tgz",
-      "integrity": "sha512-fL0DhAzGWyyFBX4VbkWSAlR9OrAzchCQJTZ8EI7l+QJwQmBg58K4UKojT9ASCc8+6QMZFNHDjzrmxDI8u/+GJA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.3.0.tgz",
+      "integrity": "sha512-mgvLJ7hez52/Iy54GGFVRs9CoO0jXWeS2Iqows5GJpL+KnFiR1afziI2s/5teQcC53vtPUtWba8PEeQHroD5Hw==",
       "requires": {
-        "@types/chai-subset": "1.3.0",
+        "@types/chai-subset": "1.3.1",
         "@types/chalk": "0.4.31",
         "@types/clone": "0.1.30",
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
         "@types/escodegen": "0.0.2",
-        "@types/estree": "0.0.34",
-        "@types/node": "6.0.81",
+        "@types/estraverse": "0.0.6",
+        "@types/estree": "0.0.37",
+        "@types/node": "6.0.88",
         "@types/parse5": "2.2.34",
         "chalk": "1.1.3",
         "clone": "2.1.1",
         "cssbeautify": "0.3.1",
         "doctrine": "2.0.0",
         "dom5": "2.3.0",
-        "escodegen": "1.8.1",
-        "espree": "3.4.3",
+        "escodegen": "1.9.0",
+        "espree": "3.5.1",
         "estraverse": "4.2.0",
-        "jsonschema": "1.1.1",
+        "jsonschema": "1.2.0",
         "parse5": "2.2.3",
-        "shady-css-parser": "0.0.8",
+        "shady-css-parser": "0.1.0",
         "strip-indent": "2.0.0"
       }
     },
@@ -1878,10 +1868,10 @@
         "any-promise": "1.3.0",
         "arrify": "1.0.1",
         "concat-stream": "1.6.0",
-        "form-data": "2.2.0",
+        "form-data": "2.3.1",
         "make-error-cause": "1.2.2",
         "throwback": "1.1.1",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "xtend": "4.0.1"
       }
     },
@@ -2061,9 +2051,9 @@
       }
     },
     "resolve": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -2092,9 +2082,9 @@
       "dev": true
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
         "glob": "7.1.2"
@@ -2137,9 +2127,9 @@
       }
     },
     "shady-css-parser": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.0.8.tgz",
-      "integrity": "sha1-Ae7FprnsjkftvakbRN/lkSeeoNE="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA=="
     },
     "shelljs": {
       "version": "0.6.1",
@@ -2175,17 +2165,17 @@
       }
     },
     "source-map": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-      "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
-      "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
-        "source-map": "0.5.6"
+        "source-map": "0.5.7"
       }
     },
     "sprintf-js": {
@@ -2264,15 +2254,9 @@
         "chalk": "1.1.3",
         "lodash": "4.17.4",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
-        "ajv-keywords": {
-          "version": "1.5.1",
-          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
-          "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -2286,9 +2270,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.0.tgz",
-          "integrity": "sha1-AwZkVh/BRslCPsfZeP4kV0N/5tA=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
@@ -2312,7 +2296,7 @@
       "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.4.1",
+        "core-js": "2.5.1",
         "deep-extend": "0.4.2",
         "feature-detect-es6": "1.3.1",
         "typical": "2.6.1",
@@ -2386,9 +2370,9 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "dev": true,
       "requires": {
         "punycode": "1.4.1"
@@ -2411,7 +2395,7 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.3.3",
+        "resolve": "1.4.0",
         "underscore.string": "3.3.4"
       },
       "dependencies": {
@@ -2444,9 +2428,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.1.tgz",
-      "integrity": "sha1-w8yxbdqgsjFN4DHn5v7onlujRrw=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "typical": {
@@ -2495,7 +2479,7 @@
         "any-promise": "1.3.0",
         "array-uniq": "1.0.3",
         "configstore": "2.1.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "detect-indent": "4.0.0",
         "graceful-fs": "4.1.11",
         "has": "1.0.1",
@@ -2505,7 +2489,7 @@
         "lockfile": "1.0.3",
         "make-error-cause": "1.2.2",
         "mkdirp": "0.5.1",
-        "object.pick": "1.2.0",
+        "object.pick": "1.3.0",
         "parse-json": "2.2.0",
         "popsicle": "8.2.0",
         "popsicle-proxy-agent": "3.0.0",
@@ -2514,14 +2498,14 @@
         "popsicle-status": "2.0.1",
         "promise-finally": "2.2.1",
         "rc": "1.2.1",
-        "rimraf": "2.6.1",
+        "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",
         "strip-bom": "2.0.0",
         "thenify": "3.3.0",
         "throat": "3.2.0",
         "touch": "1.0.0",
-        "typescript": "2.4.1",
+        "typescript": "2.5.2",
         "xtend": "4.0.1",
         "zip-object": "0.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "espree": "^3.4.0",
     "mkdirp": "^0.5.1",
     "parse5": "^2.2.2",
-    "polymer-analyzer": "^2.0.0",
+    "polymer-analyzer": "^2.3.0",
     "source-map": "^0.5.6"
   },
   "devDependencies": {

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -470,7 +470,8 @@ export class Bundler {
       bundle: AssignedBundle,
       excludes?: string[],
       rewriteUrlsInTemplates?: boolean) {
-    const cssLinks = dom5.queryAll(ast, matchers.externalStyle);
+    const cssLinks = dom5.queryAll(
+        ast, matchers.externalStyle, undefined, dom5.childNodesIncludeTemplate);
     for (const cssLink of cssLinks) {
       await importUtils.inlineStylesheet(
           this.analyzer,

--- a/src/import-utils.ts
+++ b/src/import-utils.ts
@@ -273,9 +273,9 @@ export async function inlineStylesheet(
 
   let newBaseUrl = document.url;
 
-  // If the css link we are about to inline is inside of a dom-module, the new
-  // base url must be calculated using the assetpath of the dom-module if
-  // present, since Polymer will honor assetpath when resolving urls in
+  // If the css link we are about to inline is inside of a dom-module, the
+  // new base url must be calculated using the assetpath of the dom-module
+  // if present, since Polymer will honor assetpath when resolving urls in
   // `<style>` tags, even inside of `<template>` tags.
   const parentDomModule =
       findAncestor(cssLink, dom5.predicates.hasTagName('dom-module'));

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -662,6 +662,24 @@ suite('Bundler', () => {
           dom5.getTextContent(styles[1]), /url\("assets\/platform\.png"\)/);
     });
 
+    test('External style links in templates are inlined', async () => {
+      const doc = await bundle(
+          'test/html/external-in-template.html', {inlineCss: true});
+      const externalStyles = dom5.queryAll(
+          doc,
+          matchers.externalStyle,
+          undefined,
+          dom5.childNodesIncludeTemplate);
+      assert.equal(externalStyles.length, 0);
+      const inlineStyles = dom5.queryAll(
+          doc,
+          matchers.styleMatcher,
+          undefined,
+          dom5.childNodesIncludeTemplate);
+      assert.equal(inlineStyles.length, 1);
+      assert.match(dom5.getTextContent(inlineStyles[0]), /content: 'external'/);
+    });
+
     test('Inlined styles observe containing dom-module assetpath', async () => {
       const doc =
           await bundle('test/html/style-rewriting.html', {inlineCss: true});

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -671,13 +671,19 @@ suite('Bundler', () => {
           undefined,
           dom5.childNodesIncludeTemplate);
       assert.equal(externalStyles.length, 0);
+
+      // There were two links to external styles in the file, now there
+      // should be two occurrences of inlined styles.  Note they are the
+      // same external styles, so inlining should be happening for each
+      // occurrence of the external style.
       const inlineStyles = dom5.queryAll(
           doc,
           matchers.styleMatcher,
           undefined,
           dom5.childNodesIncludeTemplate);
-      assert.equal(inlineStyles.length, 1);
+      assert.equal(inlineStyles.length, 2);
       assert.match(dom5.getTextContent(inlineStyles[0]), /content: 'external'/);
+      assert.match(dom5.getTextContent(inlineStyles[1]), /content: 'external'/);
     });
 
     test('Inlined styles observe containing dom-module assetpath', async () => {

--- a/test/html/external-in-template.html
+++ b/test/html/external-in-template.html
@@ -20,5 +20,12 @@
         <script src="external/external.js"></script>
       </template>
     </dom-module>
+
+    <dom-module id="my-other-element">
+      <template>
+        <link rel="stylesheet" href="external/external.css">
+        <script src="external/external.js"></script>
+      </template>
+    </dom-module>
   </body>
 </html>

--- a/test/html/external-in-template.html
+++ b/test/html/external-in-template.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<!--
+    @license
+    Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>External Resources</title>
+  </head>
+  <body>
+    <dom-module id="my-element">
+      <template>
+        <link rel="stylesheet" href="external/external.css">
+        <script src="external/external.js"></script>
+      </template>
+    </dom-module>
+  </body>
+</html>


### PR DESCRIPTION
- [x] CHANGELOG.md has been updated
- Fixed [issue #600](https://github.com/Polymer/polymer-bundler/issues/600) where `<link rel=stylesheet>` inside a `<template>` was not inlined.  If you want to exclude a specific stylesheet from inlining, you can add its path the the `excludes` option (or `--exclude` on command line).
 