### PR TITLE
Added .type to Bundle class in preparation of JavaScript module type bundles.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] Upgraded to use `polymer-analyzer` version `3.0.0-pre.10` which requires the `ResolvedUrl` type in nearly all places where URLs are exchanged and provides strict typing on URLs used globally.  Eliminated the local `UrlString` type.
 - [BREAKING] Removed `relativeUrl` function from `url-utils`, shifting responsibility to `Bundler#analyzer.urlResolver.relative()`.
 - [BREAKING] Removed `import-utils.ts` and migrated all HTML-specific bundling code out of it and out of `bundler.ts` into a new class `HtmlBundler`.  Renamed `ast-utils.ts` to `parse5-utils.ts` since "ast" is ambiguous when we have JavaScript ASTs coming in.
-- [BREAKING] `Bundle` class now has a required `type` property and as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
+- [BREAKING] `Bundle` class now has a required `type` property as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
 - The `BundleResult` returned by `Bundler#bundle()` includes serialized contents instead of just the root AST node of bundled document.
 <!-- Add new, unreleased changes here. -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] Upgraded to use `polymer-analyzer` version `3.0.0-pre.10` which requires the `ResolvedUrl` type in nearly all places where URLs are exchanged and provides strict typing on URLs used globally.  Eliminated the local `UrlString` type.
 - [BREAKING] Removed `relativeUrl` function from `url-utils`, shifting responsibility to `Bundler#analyzer.urlResolver.relative()`.
 - [BREAKING] Removed `import-utils.ts` and migrated all HTML-specific bundling code out of it and out of `bundler.ts` into a new class `HtmlBundler`.  Renamed `ast-utils.ts` to `parse5-utils.ts` since "ast" is ambiguous when we have JavaScript ASTs coming in.
+- [BREAKING] `Bundle` class now has a required `type` property and as first argument to its constructor.
 - The `BundleResult` returned by `Bundler#bundle()` includes serialized contents instead of just the root AST node of bundled document.
 <!-- Add new, unreleased changes here. -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] Upgraded to use `polymer-analyzer` version `3.0.0-pre.10` which requires the `ResolvedUrl` type in nearly all places where URLs are exchanged and provides strict typing on URLs used globally.  Eliminated the local `UrlString` type.
 - [BREAKING] Removed `relativeUrl` function from `url-utils`, shifting responsibility to `Bundler#analyzer.urlResolver.relative()`.
 - [BREAKING] Removed `import-utils.ts` and migrated all HTML-specific bundling code out of it and out of `bundler.ts` into a new class `HtmlBundler`.  Renamed `ast-utils.ts` to `parse5-utils.ts` since "ast" is ambiguous when we have JavaScript ASTs coming in.
-- [BREAKING] `Bundle` class now has a required `type` property and as first argument to its constructor.
+- [BREAKING] `Bundle` class now has a required `type` property and as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
 - The `BundleResult` returned by `Bundler#bundle()` includes serialized contents instead of just the root AST node of bundled document.
 <!-- Add new, unreleased changes here. -->
 

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -14,6 +14,7 @@
 
 import * as clone from 'clone';
 import {PackageRelativeUrl, ResolvedUrl, UrlResolver} from 'polymer-analyzer';
+import {uniq} from './utils';
 
 /**
  * A bundle strategy function is used to transform an array of bundles.
@@ -33,17 +34,13 @@ export type BundleUrlMapper = (bundles: Bundle[]) => Map<ResolvedUrl, Bundle>;
  */
 export type TransitiveDependenciesMap = Map<ResolvedUrl, Set<ResolvedUrl>>;
 
+export type BundleType = 'html';
+
 /**
  * A bundle is a grouping of files which serve the need of one or more
  * entrypoint files.
  */
 export class Bundle {
-  // Set of all dependant entrypoint URLs of this bundle.
-  entrypoints: Set<ResolvedUrl>;
-
-  // Set of all files included in the bundle.
-  files: Set<ResolvedUrl>;
-
   // Set of imports which should be removed when encountered.
   stripImports = new Set<ResolvedUrl>();
 
@@ -55,9 +52,13 @@ export class Bundle {
   inlinedScripts = new Set<ResolvedUrl>();
   inlinedStyles = new Set<ResolvedUrl>();
 
-  constructor(entrypoints?: Set<ResolvedUrl>, files?: Set<ResolvedUrl>) {
-    this.entrypoints = entrypoints || new Set<ResolvedUrl>();
-    this.files = files || new Set<ResolvedUrl>();
+  constructor(
+      // Filetype discriminator for Bundles.
+      public type: BundleType,
+      // Set of all dependant entrypoint URLs of this bundle.
+      public entrypoints: Set<ResolvedUrl> = new Set(),
+      // Set of all files included in the bundle.
+      public files: Set<ResolvedUrl> = new Set()) {
   }
 }
 
@@ -180,8 +181,10 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
     // entrypoints.
     let bundle =
         bundles.find((bundle) => setEquals(entrypoints, bundle.entrypoints));
+
     if (!bundle) {
-      bundle = new Bundle(entrypoints);
+      const type = 'html';
+      bundle = new Bundle(type, entrypoints);
       bundles.push(bundle);
     }
     bundle.files.add(dep);
@@ -326,7 +329,17 @@ export function generateNoBackLinkStrategy(urls: ResolvedUrl[]):
  * files of all bundles represented.
  */
 export function mergeBundles(bundles: Bundle[]): Bundle {
-  const newBundle = new Bundle();
+  if (bundles.length === 0) {
+    throw new Error('Can not merge 0 bundles.');
+  }
+  const bundleTypes = uniq(bundles, (b: Bundle) => b.type);
+  if (bundleTypes.size > 1) {
+    throw new Error(
+        'Can not merge bundles of different types: ' +
+        [...bundleTypes].join(' and '));
+  }
+  const bundleType = bundles[0].type;
+  const newBundle = new Bundle(bundleType);
   for (const {
          entrypoints,
          files,

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -34,7 +34,10 @@ export type BundleUrlMapper = (bundles: Bundle[]) => Map<ResolvedUrl, Bundle>;
  */
 export type TransitiveDependenciesMap = Map<ResolvedUrl, Set<ResolvedUrl>>;
 
-export type BundleType = 'html';
+/**
+ * The output format of the bundle.
+ */
+export type BundleType = 'html-fragment' | 'es6-module';
 
 /**
  * A bundle is a grouping of files which serve the need of one or more
@@ -183,7 +186,7 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
         bundles.find((bundle) => setEquals(entrypoints, bundle.entrypoints));
 
     if (!bundle) {
-      const type = 'html';
+      const type = 'html-fragment';
       bundle = new Bundle(type, entrypoints);
       bundles.push(bundle);
     }

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -59,9 +59,9 @@ export class Bundle {
       // Filetype discriminator for Bundles.
       public type: BundleType,
       // Set of all dependant entrypoint URLs of this bundle.
-      public entrypoints: Set<ResolvedUrl> = new Set(),
+      public entrypoints = new Set<ResolvedUrl>(),
       // Set of all files included in the bundle.
-      public files: Set<ResolvedUrl> = new Set()) {
+      public files = new Set<ResolvedUrl>()) {
   }
 }
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -34,7 +34,7 @@ suite('BundleManifest', () => {
     const arrowSplit = serialized.split(/->/);
     const entrypoints = arrowSplit[0].slice(1, -1).split(',') as ResolvedUrl[];
     const files = arrowSplit[1].slice(1, -1).split(',') as ResolvedUrl[];
-    return new Bundle(new Set(entrypoints), new Set(files));
+    return new Bundle('html', new Set(entrypoints), new Set(files));
   }
 
   /**

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -24,22 +24,6 @@ chai.config.showDiff = true;
 
 const assert = chai.assert;
 
-suite('Bundle', () => {
-
-  suite('mergeBundles()', () => {
-
-    test('can not work unless at least one Bundle provided', () => {
-      assert.throws(() => mergeBundles([]));
-    });
-
-    test('can not merge bundles of different types', () => {
-      assert.throws(
-          () => mergeBundles(
-              [new Bundle('html-fragment'), new Bundle('es6-module')]));
-    });
-  });
-});
-
 suite('BundleManifest', () => {
 
   /**
@@ -62,6 +46,30 @@ suite('BundleManifest', () => {
     const files = Array.from(bundle.files).sort().join();
     return `[${entrypoints}]->[${files}]`;
   }
+
+  suite('mergeBundles()', () => {
+
+    test('can not work unless at least one Bundle provided', () => {
+      assert.throws(() => mergeBundles([]));
+    });
+
+    test('can not merge bundles of different types', () => {
+      assert.throws(
+          () => mergeBundles([
+            new Bundle('html-fragment', new Set([r`A`]), new Set([r`X`])),
+            new Bundle('es6-module', new Set([r`B`]), new Set([r`Y`])),
+          ]));
+    });
+
+    test('can successfully merge bundles of same type', () => {
+      assert.equal(
+          serializeBundle(mergeBundles([
+            new Bundle('html-fragment', new Set([r`A`]), new Set([r`X`])),
+            new Bundle('html-fragment', new Set([r`B`]), new Set([r`Y`])),
+          ])),
+          '[A,B]->[X,Y]');
+    });
+  });
 
   suite('constructor and generated maps', () => {
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -18,11 +18,27 @@ import * as chai from 'chai';
 import {ResolvedUrl} from 'polymer-analyzer';
 import {resolvedUrl as r} from 'polymer-analyzer/lib/test/test-utils';
 
-import {Bundle, BundleManifest, composeStrategies, generateBundles, generateCountingSharedBundleUrlMapper, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedBundleUrlMapper, generateSharedDepsMergeStrategy, generateShellMergeStrategy, TransitiveDependenciesMap} from '../bundle-manifest';
+import {Bundle, BundleManifest, composeStrategies, generateBundles, generateCountingSharedBundleUrlMapper, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedBundleUrlMapper, generateSharedDepsMergeStrategy, generateShellMergeStrategy, mergeBundles, TransitiveDependenciesMap} from '../bundle-manifest';
 
 chai.config.showDiff = true;
 
 const assert = chai.assert;
+
+suite('Bundle', () => {
+
+  suite('mergeBundles()', () => {
+
+    test('can not work unless at least one Bundle provided', () => {
+      assert.throws(() => mergeBundles([]));
+    });
+
+    test('can not merge bundles of different types', () => {
+      assert.throws(
+          () => mergeBundles(
+              [new Bundle('html-fragment'), new Bundle('es6-module')]));
+    });
+  });
+});
 
 suite('BundleManifest', () => {
 
@@ -34,7 +50,7 @@ suite('BundleManifest', () => {
     const arrowSplit = serialized.split(/->/);
     const entrypoints = arrowSplit[0].slice(1, -1).split(',') as ResolvedUrl[];
     const files = arrowSplit[1].slice(1, -1).split(',') as ResolvedUrl[];
-    return new Bundle('html', new Set(entrypoints), new Set(files));
+    return new Bundle('html-fragment', new Set(entrypoints), new Set(files));
   }
 
   /**

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -79,22 +79,22 @@ suite('Bundler', () => {
 
   const inputPath = 'default.html';
 
-  async function bundle(inputPath: string, opts?: BundlerOptions):
-      Promise<BundledDocument> {
-        // Don't modify options directly because test-isolation problems occur.
-        bundler = getBundler(opts);
-        const resolvedInputPath = resolve(inputPath)!;
-        const manifest = await bundler.generateManifest([resolvedInputPath]);
-        const bundleResult = await bundler.bundle(manifest);
-        const bundleForFile =
-            bundleResult.manifest.getBundleForFile(resolvedInputPath);
-        if (!bundleForFile) {
-          throw new Error(`Unable to find bundle for ${resolvedInputPath}`);
-        }
-        documentBundle = bundleForFile.bundle;
-        const {documents} = bundleResult;
-        return documents.get(resolvedInputPath)!;
-      }
+  async function bundle(
+      inputPath: string, opts?: BundlerOptions): Promise<BundledDocument> {
+    // Don't modify options directly because test-isolation problems occur.
+    bundler = getBundler(opts);
+    const resolvedInputPath = resolve(inputPath)!;
+    const manifest = await bundler.generateManifest([resolvedInputPath]);
+    const bundleResult = await bundler.bundle(manifest);
+    const bundleForFile =
+        bundleResult.manifest.getBundleForFile(resolvedInputPath);
+    if (!bundleForFile) {
+      throw new Error(`Unable to find bundle for ${resolvedInputPath}`);
+    }
+    documentBundle = bundleForFile.bundle;
+    const {documents} = bundleResult;
+    return documents.get(resolvedInputPath)!;
+  }
 
   suite('Default Options', () => {
 
@@ -170,9 +170,11 @@ suite('Bundler', () => {
             strategy: (bundles: Bundle[]): Bundle[] => {
               return [
                 new Bundle(
+                    'html',
                     new Set([resolve('default.html')]),
                     new Set([resolve('default.html')])),
                 new Bundle(
+                    'html',
                     new Set(),  //
                     new Set([resolve('imports/simple-import.html')]))
               ];

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -79,22 +79,22 @@ suite('Bundler', () => {
 
   const inputPath = 'default.html';
 
-  async function bundle(
-      inputPath: string, opts?: BundlerOptions): Promise<BundledDocument> {
-    // Don't modify options directly because test-isolation problems occur.
-    bundler = getBundler(opts);
-    const resolvedInputPath = resolve(inputPath)!;
-    const manifest = await bundler.generateManifest([resolvedInputPath]);
-    const bundleResult = await bundler.bundle(manifest);
-    const bundleForFile =
-        bundleResult.manifest.getBundleForFile(resolvedInputPath);
-    if (!bundleForFile) {
-      throw new Error(`Unable to find bundle for ${resolvedInputPath}`);
-    }
-    documentBundle = bundleForFile.bundle;
-    const {documents} = bundleResult;
-    return documents.get(resolvedInputPath)!;
-  }
+  async function bundle(inputPath: string, opts?: BundlerOptions):
+      Promise<BundledDocument> {
+        // Don't modify options directly because test-isolation problems occur.
+        bundler = getBundler(opts);
+        const resolvedInputPath = resolve(inputPath)!;
+        const manifest = await bundler.generateManifest([resolvedInputPath]);
+        const bundleResult = await bundler.bundle(manifest);
+        const bundleForFile =
+            bundleResult.manifest.getBundleForFile(resolvedInputPath);
+        if (!bundleForFile) {
+          throw new Error(`Unable to find bundle for ${resolvedInputPath}`);
+        }
+        documentBundle = bundleForFile.bundle;
+        const {documents} = bundleResult;
+        return documents.get(resolvedInputPath)!;
+      }
 
   suite('Default Options', () => {
 
@@ -170,11 +170,11 @@ suite('Bundler', () => {
             strategy: (bundles: Bundle[]): Bundle[] => {
               return [
                 new Bundle(
-                    'html',
+                    'html-fragment',
                     new Set([resolve('default.html')]),
                     new Set([resolve('default.html')])),
                 new Bundle(
-                    'html',
+                    'html-fragment',
                     new Set(),  //
                     new Set([resolve('imports/simple-import.html')]))
               ];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,3 +25,15 @@ export function find<T>(items: Iterable<T>, predicate: (item: T) => boolean): T|
     }
   }
 }
+
+/**
+ * Returns a set of unique/distinct values returned by calling the given
+ * function on each item.
+ */
+export function uniq<T, R>(items: Iterable<T>, map: (item: T) => R): Set<R> {
+  const results = new Set();
+  for (const item of items) {
+    results.add(map(item));
+  }
+  return results;
+}


### PR DESCRIPTION
- [BREAKING] `Bundle` class now has a required `type` property and as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
- [x] CHANGELOG.md has been updated
