### PR TITLE
Extending DepsIndex and Bundle generation to support ES6 modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] Removed `relativeUrl` function from `url-utils`, shifting responsibility to `Bundler#analyzer.urlResolver.relative()`.
 - [BREAKING] Removed `import-utils.ts` and migrated all HTML-specific bundling code out of it and out of `bundler.ts` into a new class `HtmlBundler`.  Renamed `ast-utils.ts` to `parse5-utils.ts` since "ast" is ambiguous when we have JavaScript ASTs coming in.
 - [BREAKING] `Bundle` class now has a required `type` property as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
+- [BREAKING] The `DepsIndex` type returned from `buildDepsIndex` has changed to a single map of entrypoints to dependencies.
 - Added support for `<script type="module">` and bundling of ES6 modules by following `import` statements.  Dynamic `import()` statements are treated similarly to the `<link rel="lazy-import">` tag in that the import target implicitly defines a new entrypoint/bundle.
 - Shared bundles containing only one file are named after the original file instead of having naming delegated to shared bundle URL mapper.
 - The `BundleResult` returned by `Bundler#bundle()` includes serialized contents instead of just the root AST node of bundled document.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] Removed `relativeUrl` function from `url-utils`, shifting responsibility to `Bundler#analyzer.urlResolver.relative()`.
 - [BREAKING] Removed `import-utils.ts` and migrated all HTML-specific bundling code out of it and out of `bundler.ts` into a new class `HtmlBundler`.  Renamed `ast-utils.ts` to `parse5-utils.ts` since "ast" is ambiguous when we have JavaScript ASTs coming in.
 - [BREAKING] `Bundle` class now has a required `type` property as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
+- Added support for `<script type="module">` and bundling of ES6 modules by following `import` statements.  Dynamic `import()` statements are treated similarly to the `<link rel="lazy-import">` tag in that the import target implicitly defines a new entrypoint/bundle.
+- Shared bundles containing only one file are named after the original file instead of having naming delegated to shared bundle URL mapper.
 - The `BundleResult` returned by `Bundler#bundle()` includes serialized contents instead of just the root AST node of bundled document.
 <!-- Add new, unreleased changes here. -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - [BREAKING] `Bundle` class now has a required `type` property as first argument to its constructor, with current possible values of `html-fragment` and `es6-module`.
 - [BREAKING] The `DepsIndex` type returned from `buildDepsIndex` has changed to a single map of entrypoints to dependencies.
 - Added support for `<script type="module">` and bundling of ES6 modules by following `import` statements.  Dynamic `import()` statements are treated similarly to the `<link rel="lazy-import">` tag in that the import target implicitly defines a new entrypoint/bundle.
-- Shared bundles containing only one file are named after the original file instead of having naming delegated to shared bundle URL mapper.
 - The `BundleResult` returned by `Bundler#bundle()` includes serialized contents instead of just the root AST node of bundled document.
 <!-- Add new, unreleased changes here. -->
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2866 @@
+{
+  "name": "polymer-bundler",
+  "version": "4.0.0-pre.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/babel-generator": {
+      "version": "6.25.1",
+      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.1.tgz",
+      "integrity": "sha512-nKNz9Ch4WP2TFZjQROhxqqS2SCk0OoDzGazJI6S+2sGgW9P7N4o3vluZAXFuPEnRqtz2A0vrrkK3tjQktxIlRw==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
+    "@types/babel-traverse": {
+      "version": "6.25.3",
+      "resolved": "https://registry.npmjs.org/@types/babel-traverse/-/babel-traverse-6.25.3.tgz",
+      "integrity": "sha512-4FaulWyA7nrXPkzoukL2VmSpxCnBZwc+MgwZqO30gtHCrtaUXnoxymdYfxzf3CZN80zjtrVzKfLlZ7FPYvrhQQ==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
+    "@types/babel-types": {
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
+      "integrity": "sha512-+3bMuktcY4a70a0KZc8aPJlEOArPuAKQYHU5ErjkOqGJdx8xuEEVK6nWogqigBOJ8nKPxRpyCUDTCPmZ3bUxGA=="
+    },
+    "@types/babylon": {
+      "version": "6.16.2",
+      "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.2.tgz",
+      "integrity": "sha512-+Jty46mPaWe1VAyZbfvgJM4BAdklLWxrT5tc/RjvCgLrtk6gzRY6AOnoWFv4p6hVxhJshDdr2hGVn56alBp97Q==",
+      "requires": {
+        "@types/babel-types": "6.25.2"
+      }
+    },
+    "@types/chai": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-3.5.2.tgz",
+      "integrity": "sha1-wRzSgX06QBt7oPWkIPNcVhObHB4="
+    },
+    "@types/chai-subset": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.1.tgz",
+      "integrity": "sha512-Aof+FLfWzBPzDgJ2uuBuPNOBHVx9Siyw4vmOcsMgsuxX1nfUWSlzpq4pdvQiaBgGjGS7vP/Oft5dpJbX4krT1A==",
+      "requires": {
+        "@types/chai": "3.5.2"
+      }
+    },
+    "@types/chalk": {
+      "version": "0.4.31",
+      "resolved": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
+      "integrity": "sha1-ox10JBprHtu5c8822XooloNKUfk="
+    },
+    "@types/clone": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
+      "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
+    },
+    "@types/cssbeautify": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@types/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "integrity": "sha1-jgvuj33suVIlDaDK6+BeMFkcF+8="
+    },
+    "@types/doctrine": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.1.tgz",
+      "integrity": "sha1-uZny2fe0PKvgoaLzm8IDvH3K2p0="
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+    },
+    "@types/mocha": {
+      "version": "2.2.48",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
+      "integrity": "sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "6.0.101",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
+      "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw=="
+    },
+    "@types/parse5": {
+      "version": "2.2.34",
+      "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
+      "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
+      "requires": {
+        "@types/node": "6.0.101"
+      }
+    },
+    "@types/source-map": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
+      "integrity": "sha512-++w4WmMbk3dS3UeHGzAG+xJOSz5Xqtjys/TBkqG3qp3SeWE7Wwezqe5eB7B51cxUyh4PW7bwVotpsLdBK0D8cw==",
+      "dev": true
+    },
+    "@types/winston": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.8.tgz",
+      "integrity": "sha512-QqR0j08RCS1AQYPMRPHikEpcmK+2aEEbcSzWLwOqyJ4FhLmHUx/WjRrnn7tTQg/y4IKnMhzskh/o7qvGIZZ7iA==",
+      "requires": {
+        "@types/node": "6.0.101"
+      }
+    },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
+    "acorn": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
+      "integrity": "sha512-XLmq3H/BVvW6/GbxKryGxWORz1ebilSsUDlyC27bXhWGWAZWkGwS6FLHjOlwFXNFoWFQEO/Df4u0YYd0K3BQgQ=="
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo="
+        }
+      }
+    },
+    "agent-base": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
+      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
+      "dev": true,
+      "requires": {
+        "extend": "3.0.1",
+        "semver": "5.0.3"
+      }
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "dev": true,
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+      "dev": true
+    },
+    "ansi-align": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "ansi-escape-sequences": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-3.0.0.tgz",
+      "integrity": "sha1-HBg5S2r5t2/5pjUJ+kl2af0s5T4=",
+      "requires": {
+        "array-back": "1.0.4"
+      }
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+    },
+    "any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
+      "dev": true
+    },
+    "archy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
+    },
+    "array-back": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-1.0.4.tgz",
+      "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
+      "requires": {
+        "typical": "2.6.1"
+      }
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "dev": true,
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+      "dev": true
+    },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
+    },
+    "babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      }
+    },
+    "babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "requires": {
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "detect-indent": "4.0.0",
+        "jsesc": "1.3.0",
+        "lodash": "4.17.5",
+        "source-map": "0.5.7",
+        "trim-right": "1.0.1"
+      }
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "requires": {
+        "babel-runtime": "6.26.0"
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
+      }
+    },
+    "babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "requires": {
+        "babel-code-frame": "6.26.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.5"
+      }
+    },
+    "babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.5",
+        "to-fast-properties": "1.0.3"
+      }
+    },
+    "babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "dev": true
+    },
+    "boxen": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "dev": true,
+      "requires": {
+        "ansi-align": "1.1.0",
+        "camelcase": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-boxes": "1.0.0",
+        "filled-array": "1.1.0",
+        "object-assign": "4.1.1",
+        "repeating": "2.0.1",
+        "string-width": "1.0.2",
+        "widest-line": "1.0.0"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "capture-stack-trace": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "1.1.0",
+        "deep-eql": "0.1.3",
+        "type-detect": "1.0.0"
+      }
+    },
+    "chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "clang-format": {
+      "version": "1.0.49",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.49.tgz",
+      "integrity": "sha1-v1L0InfUHtNhhZH4cUWs9krOt+Y=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "glob": "7.1.2",
+        "resolve": "1.5.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        }
+      }
+    },
+    "cli-boxes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "clone": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
+      "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs="
+    },
+    "co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
+    "columnify": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/columnify/-/columnify-1.5.4.tgz",
+      "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
+      "dev": true,
+      "requires": {
+        "strip-ansi": "3.0.1",
+        "wcwidth": "1.0.1"
+      }
+    },
+    "combined-stream": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
+      "requires": {
+        "delayed-stream": "1.0.0"
+      }
+    },
+    "command-line-args": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-3.0.5.tgz",
+      "integrity": "sha1-W9StReeYPlwTRJGOQCgO4mk8WsA=",
+      "requires": {
+        "array-back": "1.0.4",
+        "feature-detect-es6": "1.4.0",
+        "find-replace": "1.0.3",
+        "typical": "2.6.1"
+      }
+    },
+    "command-line-usage": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-3.0.8.tgz",
+      "integrity": "sha1-tqIJeMGzg0d/XBGlKUKLiAv+D00=",
+      "requires": {
+        "ansi-escape-sequences": "3.0.0",
+        "array-back": "1.0.4",
+        "feature-detect-es6": "1.4.0",
+        "table-layout": "0.3.0",
+        "typical": "2.6.1"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4",
+        "typedarray": "0.0.6"
+      }
+    },
+    "configstore": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "dev": true,
+      "requires": {
+        "dot-prop": "3.0.0",
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1",
+        "os-tmpdir": "1.0.2",
+        "osenv": "0.1.4",
+        "uuid": "2.0.3",
+        "write-file-atomic": "1.3.4",
+        "xdg-basedir": "2.0.0"
+      }
+    },
+    "core-js": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+      "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
+      "requires": {
+        "capture-stack-trace": "1.0.0"
+      }
+    },
+    "cssbeautify": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cssbeautify/-/cssbeautify-0.3.1.tgz",
+      "integrity": "sha1-Et0fc0A1wub6ymfcvc73TkKBE5c="
+    },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
+    "d": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "dev": true,
+      "requires": {
+        "es5-ext": "0.10.38"
+      }
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "deep-extend": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "dev": true,
+      "requires": {
+        "clone": "1.0.3"
+      },
+      "dependencies": {
+        "clone": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
+          "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8=",
+          "dev": true
+        }
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      }
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "requires": {
+        "repeating": "2.0.1"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "dom5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/dom5/-/dom5-2.3.0.tgz",
+      "integrity": "sha1-+CBJdb0NrLvltYqKk//B/tD/zSo=",
+      "requires": {
+        "@types/clone": "0.1.30",
+        "@types/node": "6.0.101",
+        "@types/parse5": "2.2.34",
+        "clone": "2.1.1",
+        "parse5": "2.2.3"
+      }
+    },
+    "dot-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "dev": true,
+      "requires": {
+        "is-obj": "1.0.1"
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "requires": {
+        "readable-stream": "2.3.4"
+      }
+    },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "0.2.1"
+      }
+    },
+    "es5-ext": {
+      "version": "0.10.38",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.38.tgz",
+      "integrity": "sha512-jCMyePo7AXbUESwbl8Qi01VSH2piY9s/a3rSU/5w/MlTIx8HPL1xn2InGN8ejt/xulcJgnTO7vqNtOAxzYd2Kg==",
+      "dev": true,
+      "requires": {
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      }
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38",
+        "es6-iterator": "2.0.3",
+        "es6-symbol": "3.1.1"
+      }
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "escope": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "dev": true,
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.2.0",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
+      "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "1.5.0",
+        "es6-map": "0.1.5",
+        "escope": "3.6.0",
+        "espree": "3.5.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "1.3.1",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.17.2",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "mkdirp": "0.5.1",
+        "optionator": "0.8.2",
+        "path-is-absolute": "1.0.1",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.6.1",
+        "strip-json-comments": "1.0.4",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
+        }
+      }
+    },
+    "espree": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
+      "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
+      "requires": {
+        "acorn": "5.4.1",
+        "acorn-jsx": "3.0.1"
+      }
+    },
+    "esprima": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "dev": true,
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.38"
+      }
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+      "dev": true
+    },
+    "extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "feature-detect-es6": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/feature-detect-es6/-/feature-detect-es6-1.4.0.tgz",
+      "integrity": "sha512-7OnRV38WLydGuGcdm/fGk2SG9uo5ljslBSbPhCfEW5Gl0lX/IliaAVXYiYUBcI0UHTbepqO4T1SkJ74K8gtcDg==",
+      "requires": {
+        "array-back": "1.0.4"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
+    },
+    "file-entry-cache": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
+      "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
+      }
+    },
+    "filled-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
+      "dev": true
+    },
+    "find-replace": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-1.0.3.tgz",
+      "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
+      "requires": {
+        "array-back": "1.0.4",
+        "test-value": "2.1.0"
+      }
+    },
+    "findup-sync": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
+      "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+      "dev": true,
+      "requires": {
+        "glob": "5.0.15"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "5.0.15",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "firebase": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-2.4.2.tgz",
+      "integrity": "sha1-ThEZ7AOWylYdinrL/xYw/qxsCjE=",
+      "dev": true,
+      "requires": {
+        "faye-websocket": "0.9.3"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.9.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.9.3.tgz",
+          "integrity": "sha1-SCpQWw3wrmJrlphm0710DNuWLoM=",
+          "dev": true,
+          "requires": {
+            "websocket-driver": "0.5.2"
+          },
+          "dependencies": {
+            "websocket-driver": {
+              "version": "0.5.2",
+              "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.5.2.tgz",
+              "integrity": "sha1-jHyF2gcTtAYFVrTXHAF3XuEmnrk=",
+              "dev": true,
+              "requires": {
+                "websocket-extensions": "0.1.1"
+              },
+              "dependencies": {
+                "websocket-extensions": {
+                  "version": "0.1.1",
+                  "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+                  "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+                  "dev": true
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "form-data": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
+      "requires": {
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "2.1.17"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "dev": true,
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
+    },
+    "globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+    },
+    "globby": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "dev": true,
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      }
+    },
+    "got": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.7.1.tgz",
+      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+      "dev": true,
+      "requires": {
+        "create-error-class": "3.0.2",
+        "duplexer2": "0.1.4",
+        "is-redirect": "1.0.0",
+        "is-retry-allowed": "1.1.0",
+        "is-stream": "1.1.0",
+        "lowercase-keys": "1.0.0",
+        "node-status-codes": "1.0.0",
+        "object-assign": "4.1.1",
+        "parse-json": "2.2.0",
+        "pinkie-promise": "2.0.1",
+        "read-all-stream": "3.1.0",
+        "readable-stream": "2.3.4",
+        "timed-out": "3.1.3",
+        "unzip-response": "1.0.2",
+        "url-parse-lax": "1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true
+    },
+    "http-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
+      "dev": true,
+      "requires": {
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.1"
+      }
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "indent": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/indent/-/indent-0.0.2.tgz",
+      "integrity": "sha1-jHnwgBkFWbaHA0uEx676l9WpEdk="
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.2.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.5",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+      "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
+    },
+    "is-absolute": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
+      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "dev": true,
+      "requires": {
+        "is-relative": "0.2.1",
+        "is-windows": "0.2.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
+    },
+    "is-my-ip-valid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+      "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+      "dev": true
+    },
+    "is-my-json-valid": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+      "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+      "dev": true,
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "is-my-ip-valid": "1.0.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
+    },
+    "is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
+    },
+    "is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+      "dev": true
+    },
+    "is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-relative": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "dev": true,
+      "requires": {
+        "is-unc-path": "0.1.2"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-unc-path": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "dev": true,
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "is-windows": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
+      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+    },
+    "js-yaml": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "4.0.0"
+      }
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "dev": true,
+      "requires": {
+        "jsonify": "0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+      "dev": true
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+      "dev": true
+    },
+    "jsonschema": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.2.tgz",
+      "integrity": "sha512-iX5OFQ6yx9NgbHCwse51ohhKgLuLL7Z5cNOeZOPIlDUtAMrxlruHLzVZxbltdHE5mEDXN+75oFOwq6Gn0MZwsA=="
+    },
+    "latest-version": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "dev": true,
+      "requires": {
+        "package-json": "2.4.0"
+      }
+    },
+    "lazy-req": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
+    },
+    "listify": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
+      "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
+      "dev": true
+    },
+    "lockfile": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.3.tgz",
+      "integrity": "sha1-Jjj8OaAzHpysGgS3F5mTHJxQ33k=",
+      "dev": true
+    },
+    "lodash": {
+      "version": "4.17.5",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "requires": {
+        "js-tokens": "3.0.2"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+      "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+      "dev": true
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "make-error": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.3.tgz",
+      "integrity": "sha512-j3dZCri3cCd23wgPqK/0/KvTN8R+W6fXDqQe8BNLbTpONjbA8SPaRr+q0BQq9bx3Q/+g68/gDIh9FW3by702Tg==",
+      "dev": true
+    },
+    "make-error-cause": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/make-error-cause/-/make-error-cause-1.2.2.tgz",
+      "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
+      "dev": true,
+      "requires": {
+        "make-error": "1.3.3"
+      }
+    },
+    "mime-db": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
+      "requires": {
+        "mime-db": "1.30.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.11"
+      }
+    },
+    "minimatch-all": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/minimatch-all/-/minimatch-all-1.1.0.tgz",
+      "integrity": "sha1-QMSWonouEo0Zv3WOdrsBoMcUV4c=",
+      "requires": {
+        "minimatch": "3.0.4"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+          "dev": true
+        },
+        "glob": {
+          "version": "3.2.11",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+      "dev": true
+    },
+    "node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
+      "dev": true
+    },
+    "nopt": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+      "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+      "dev": true,
+      "requires": {
+        "abbrev": "1.1.1"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "3.0.1"
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1.0.2"
+      }
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8",
+        "wordwrap": "0.0.3"
+      },
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
+        }
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+      "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2",
+        "os-tmpdir": "1.0.2"
+      }
+    },
+    "package-json": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "dev": true,
+      "requires": {
+        "got": "5.7.1",
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0",
+        "semver": "5.5.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "1.3.1"
+      }
+    },
+    "parse5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-2.2.3.tgz",
+      "integrity": "sha1-DE/EHBAAxea5PUiwP4CDg3g06fY="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "2.0.4"
+      }
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+      "dev": true
+    },
+    "plylog": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/plylog/-/plylog-0.5.0.tgz",
+      "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
+      "requires": {
+        "@types/node": "4.2.23",
+        "@types/winston": "2.3.8",
+        "winston": "2.4.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "4.2.23",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-4.2.23.tgz",
+          "integrity": "sha512-U6IchCNLRyswc9p6G6lxWlbE+KwAhZp6mGo6MD2yWpmFomhYmetK+c98OpKyvphNn04CU3aXeJrXdOqbXVTS/w=="
+        }
+      }
+    },
+    "polymer-analyzer": {
+      "version": "3.0.0-pre.12",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.12.tgz",
+      "integrity": "sha512-QQL70IC85hI6q9uQeresEMcT1Qf8YR/zDe1qG8WWeeFAZk8z0lmzUpsfcAWz+bM4wpDdXrtd4HitIs4p0CHl/w==",
+      "requires": {
+        "@types/babel-generator": "6.25.1",
+        "@types/babel-traverse": "6.25.3",
+        "@types/babel-types": "6.25.2",
+        "@types/babylon": "6.16.2",
+        "@types/chai-subset": "1.3.1",
+        "@types/chalk": "0.4.31",
+        "@types/clone": "0.1.30",
+        "@types/cssbeautify": "0.3.1",
+        "@types/doctrine": "0.0.1",
+        "@types/minimatch": "3.0.3",
+        "@types/node": "6.0.101",
+        "@types/parse5": "2.2.34",
+        "babel-generator": "6.26.1",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "chalk": "1.1.3",
+        "clone": "2.1.1",
+        "cssbeautify": "0.3.1",
+        "doctrine": "2.1.0",
+        "dom5": "3.0.0",
+        "indent": "0.0.2",
+        "jsonschema": "1.2.2",
+        "minimatch": "3.0.4",
+        "parse5": "4.0.0",
+        "polymer-project-config": "3.8.1",
+        "shady-css-parser": "0.1.0",
+        "stable": "0.1.6",
+        "strip-indent": "2.0.0",
+        "vscode-uri": "1.0.1"
+      },
+      "dependencies": {
+        "dom5": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/dom5/-/dom5-3.0.0.tgz",
+          "integrity": "sha512-PbE+7C4Sh1dHDTLNuSDaMUGD1ivDiSZw0L+a9xVUzUKeQ8w3vdzfKHRA07CxcrFZZOa1SGl2nIJ9T49j63q+bg==",
+          "requires": {
+            "@types/parse5": "2.2.34",
+            "clone": "2.1.1",
+            "parse5": "4.0.0"
+          }
+        },
+        "parse5": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+          "integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA=="
+        }
+      }
+    },
+    "polymer-project-config": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.8.1.tgz",
+      "integrity": "sha512-MLvnM9gexFWg7nynY24eHZG6NLXocmk718sVds/sx2CAJ6iihhC0JMhhOIa6jnad9KQrHyGl/cs3mMRaaub5Fg==",
+      "requires": {
+        "@types/node": "6.0.101",
+        "jsonschema": "1.2.2",
+        "minimatch-all": "1.1.0",
+        "plylog": "0.5.0"
+      }
+    },
+    "popsicle": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/popsicle/-/popsicle-8.2.0.tgz",
+      "integrity": "sha1-/0QBAFyrQ6lBipFBBhHAAZdxLSE=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "arrify": "1.0.1",
+        "concat-stream": "1.6.0",
+        "form-data": "2.3.2",
+        "make-error-cause": "1.2.2",
+        "throwback": "1.1.1",
+        "tough-cookie": "2.3.3",
+        "xtend": "4.0.1"
+      }
+    },
+    "popsicle-proxy-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-proxy-agent/-/popsicle-proxy-agent-3.0.0.tgz",
+      "integrity": "sha1-uRM8VdlFdZq37mG3cRNkYg066tw=",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0"
+      }
+    },
+    "popsicle-retry": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/popsicle-retry/-/popsicle-retry-3.2.1.tgz",
+      "integrity": "sha1-4G6GZTO0KnoSPrMwy+Y6fOvLoQw=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "xtend": "4.0.1"
+      }
+    },
+    "popsicle-rewrite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/popsicle-rewrite/-/popsicle-rewrite-1.0.0.tgz",
+      "integrity": "sha1-HdTo6pwxgjUfuCD4eTTZkvf7kAc=",
+      "dev": true
+    },
+    "popsicle-status": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/popsicle-status/-/popsicle-status-2.0.1.tgz",
+      "integrity": "sha1-jdcMT+fGlBCa3XhP/oDqysHnso0=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "dev": true
+    },
+    "progress": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+      "dev": true
+    },
+    "promise-finally": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/promise-finally/-/promise-finally-2.2.1.tgz",
+      "integrity": "sha1-ImFsS6kCkW6Yi9RsVNfKoIkQzXc=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
+    },
+    "rc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
+      "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
+        }
+      }
+    },
+    "read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "2.0.1",
+        "readable-stream": "2.3.4"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
+      "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
+    },
+    "reduce-flatten": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-1.0.1.tgz",
+      "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
+    },
+    "regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+    },
+    "registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.5",
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
+      "requires": {
+        "rc": "1.2.5"
+      }
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "requires": {
+        "is-finite": "1.0.2"
+      }
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
+    },
+    "resolve": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+      "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
+      }
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
+    },
+    "rewire": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-2.5.2.tgz",
+      "integrity": "sha1-ZCfee3/u+n02QBUH62SlOFvFjcc=",
+      "dev": true
+    },
+    "rimraf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2"
+      }
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "dev": true,
+      "requires": {
+        "once": "1.4.0"
+      }
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+      "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
+      "dev": true
+    },
+    "semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
+      "requires": {
+        "semver": "5.0.3"
+      }
+    },
+    "shady-css-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA=="
+    },
+    "shelljs": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.6.1.tgz",
+      "integrity": "sha1-7GIRvtGSBEIIj+D3Cyg3Iy7SyKg=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
+      "dev": true
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+      "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "1.1.0"
+      }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+    },
+    "source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "requires": {
+        "source-map": "0.5.7"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "stable": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
+      "integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+    },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
+    "string-template": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
+      "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "0.2.1"
+      }
+    },
+    "strip-indent": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+      "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g="
+    },
+    "strip-json-comments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+      "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "table": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "dev": true,
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.5",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "table-layout": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-0.3.0.tgz",
+      "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
+      "requires": {
+        "array-back": "1.0.4",
+        "core-js": "2.5.3",
+        "deep-extend": "0.4.2",
+        "feature-detect-es6": "1.4.0",
+        "typical": "2.6.1",
+        "wordwrapjs": "2.0.0"
+      }
+    },
+    "test-value": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/test-value/-/test-value-2.1.0.tgz",
+      "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
+      "requires": {
+        "array-back": "1.0.4",
+        "typical": "2.6.1"
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "thenify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "throat": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
+      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "throwback": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/throwback/-/throwback-1.1.1.tgz",
+      "integrity": "sha1-8AfnwXYEptFtegfEGqDo/txhhKQ=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0"
+      }
+    },
+    "timed-out": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-3.1.3.tgz",
+      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
+      "dev": true
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "touch": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
+      "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
+      "dev": true,
+      "requires": {
+        "nopt": "1.0.10"
+      }
+    },
+    "tough-cookie": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
+      "requires": {
+        "punycode": "1.4.1"
+      }
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+    },
+    "tslint": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-3.15.1.tgz",
+      "integrity": "sha1-2hZcqT2P3CwIa1EWXuG6y0jJjqU=",
+      "dev": true,
+      "requires": {
+        "colors": "1.1.2",
+        "diff": "2.2.3",
+        "findup-sync": "0.3.0",
+        "glob": "7.1.2",
+        "optimist": "0.6.1",
+        "resolve": "1.5.0",
+        "underscore.string": "3.3.4"
+      },
+      "dependencies": {
+        "colors": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+          "dev": true
+        },
+        "diff": {
+          "version": "2.2.3",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-2.2.3.tgz",
+          "integrity": "sha1-YOr9DSjukG5Oj/ClLBIpUhAzv5k=",
+          "dev": true
+        }
+      }
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
+      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "dev": true
+    },
+    "typical": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-2.6.1.tgz",
+      "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
+    },
+    "typings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/typings/-/typings-1.5.0.tgz",
+      "integrity": "sha1-udI2zx03RghU+MZx6kldlAW4ED8=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "archy": "1.0.0",
+        "bluebird": "3.5.1",
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "columnify": "1.5.4",
+        "elegant-spinner": "1.0.1",
+        "has-unicode": "2.0.1",
+        "listify": "1.0.0",
+        "log-update": "1.0.2",
+        "minimist": "1.2.0",
+        "promise-finally": "2.2.1",
+        "typings-core": "1.6.1",
+        "update-notifier": "1.0.3",
+        "wordwrap": "1.0.0",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
+    },
+    "typings-core": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/typings-core/-/typings-core-1.6.1.tgz",
+      "integrity": "sha1-zkspMeovGbuPPay+xpmDrE6WSjc=",
+      "dev": true,
+      "requires": {
+        "any-promise": "1.3.0",
+        "array-uniq": "1.0.3",
+        "configstore": "2.1.0",
+        "debug": "2.6.9",
+        "detect-indent": "4.0.0",
+        "graceful-fs": "4.1.11",
+        "has": "1.0.1",
+        "invariant": "2.2.2",
+        "is-absolute": "0.2.6",
+        "listify": "1.0.0",
+        "lockfile": "1.0.3",
+        "make-error-cause": "1.2.2",
+        "mkdirp": "0.5.1",
+        "object.pick": "1.3.0",
+        "parse-json": "2.2.0",
+        "popsicle": "8.2.0",
+        "popsicle-proxy-agent": "3.0.0",
+        "popsicle-retry": "3.2.1",
+        "popsicle-rewrite": "1.0.0",
+        "popsicle-status": "2.0.1",
+        "promise-finally": "2.2.1",
+        "rc": "1.2.5",
+        "rimraf": "2.6.2",
+        "sort-keys": "1.1.2",
+        "string-template": "1.0.0",
+        "strip-bom": "2.0.0",
+        "thenify": "3.3.0",
+        "throat": "3.2.0",
+        "touch": "1.0.0",
+        "typescript": "2.7.1",
+        "xtend": "4.0.1",
+        "zip-object": "0.1.0"
+      }
+    },
+    "unc-path-regex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "dev": true
+    },
+    "underscore.string": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
+    },
+    "unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
+      "dev": true
+    },
+    "update-notifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+      "dev": true,
+      "requires": {
+        "boxen": "0.6.0",
+        "chalk": "1.1.3",
+        "configstore": "2.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "2.0.0",
+        "lazy-req": "1.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "2.0.0"
+      }
+    },
+    "url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "1.0.4"
+      }
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "uuid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
+      "dev": true
+    },
+    "vscode-uri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-1.0.1.tgz",
+      "integrity": "sha1-Eahr7+rDxKo+wIYjZRo8gabQu8g="
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "dev": true,
+      "requires": {
+        "defaults": "1.0.3"
+      }
+    },
+    "widest-line": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "dev": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
+    "winston": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wordwrapjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-2.0.0.tgz",
+      "integrity": "sha1-q1X2leYRjak4WP3XDAU9HF4BrCA=",
+      "requires": {
+        "array-back": "1.0.4",
+        "feature-detect-es6": "1.4.0",
+        "reduce-flatten": "1.0.1",
+        "typical": "2.6.1"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
+    },
+    "write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "imurmurhash": "0.1.4",
+        "slide": "1.1.6"
+      }
+    },
+    "xdg-basedir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+      "dev": true,
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
+    },
+    "zip-object": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zip-object/-/zip-object-0.1.0.tgz",
+      "integrity": "sha1-waDaBMiMg3dW4khoCgP/kC7D9To=",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "espree": "^3.5.2",
     "mkdirp": "^0.5.1",
     "parse5": "^2.2.2",
-    "polymer-analyzer": "^3.0.0-pre.10",
+    "polymer-analyzer": "^3.0.0-pre.12",
     "source-map": "^0.5.6",
     "vscode-uri": "^1.0.1"
   },

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -188,7 +188,9 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
         bundles.find((bundle) => setEquals(entrypoints, bundle.entrypoints));
 
     if (!bundle) {
-      const type = 'html-fragment';
+      const type = [...entrypoints].some((e) => !!e.match(/>/)) ?
+          'es6-module' :
+          'html-fragment';
       bundle = new Bundle(type, entrypoints);
       bundles.push(bundle);
     }
@@ -291,10 +293,7 @@ export function generateSharedBundleUrlMapper(
     const urlMap = new Map<ResolvedUrl, Bundle>();
     const sharedBundles: Bundle[] = [];
     for (const bundle of bundles) {
-      const bundleUrl = getBundleEntrypoint(bundle) ||
-          // If a bundle contains only a single file it should just be named
-          // the same as that file even if it is a shared bundle.
-          bundle.files.size === 1 && bundle.files.entries().next().value[0];
+      const bundleUrl = getBundleEntrypoint(bundle);
       if (bundleUrl) {
         urlMap.set(bundleUrl, bundle);
       } else {

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -380,7 +380,7 @@ export function generateNoBackLinkStrategy(urls: ResolvedUrl[]):
 
 /**
  * Given an Array of bundles, produce a single bundle with the entrypoints and
- * files of all bundles represented.  My default, bundles of different types
+ * files of all bundles represented.  By default, bundles of different types
  * can not be merged, but this constraint can be skipped by providing
  * `ignoreTypeCheck` argument with value `true`.
  */

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -421,19 +421,26 @@ export function mergeBundles(
 }
 
 /**
- * Return a new bundle array where all bundles within it matching the predicate
- * are merged.
+ * Return a new bundle array where bundles within it matching the predicate
+ * are merged together.  Note that merge operations are segregated by type so
+ * that no attempt to merge bundles of different types will occur.
  */
 export function mergeMatchingBundles(
     bundles: Bundle[], predicate: (bundle: Bundle) => boolean): Bundle[] {
   const newBundles = Array.from(bundles);
   const bundlesToMerge = newBundles.filter(predicate);
-  if (bundlesToMerge.length > 1) {
-    for (const bundle of bundlesToMerge) {
-      newBundles.splice(newBundles.indexOf(bundle), 1);
+
+  const types = [...new Set(bundlesToMerge.map((b) => b.type))].sort();
+  types.forEach((bundleType) => {
+    const bundlesToMergeForType =
+        bundlesToMerge.filter((b) => b.type === bundleType);
+    if (bundlesToMergeForType.length > 1) {
+      for (const bundle of bundlesToMergeForType) {
+        newBundles.splice(newBundles.indexOf(bundle), 1);
+      }
+      newBundles.push(mergeBundles(bundlesToMergeForType));
     }
-    newBundles.push(mergeBundles(bundlesToMerge));
-  }
+  });
   return newBundles;
 }
 

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -201,12 +201,9 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
 /**
  * Instances of `<script type="module">` generate synthetic entrypoints in the
  * depsIndex and are treated as entrypoints during the initial phase of
- * `generateBundles`.  Before handing bundles to the strategy function, if
- * script inlining is enabled, any bundle which provides dependencies to a
- * single synthetic entrypoint of this type (aka a single entrypoint sub-bundle)
- * are merged back into the bundle for the HTML containing the script tag, by
- * use of this function, which performs the merge(s) in-place to the provided
- * array of bundles.
+ * `generateBundles`.  Any bundle which provides dependencies to a single
+ * synthetic entrypoint of this type (aka a single entrypoint sub-bundle) are
+ * merged back into the bundle for the HTML containing the script tag.
  *
  * For example, the following bundles:
  *   `[a]->[a], [a>1]->[x], [a>1,a>2]->[y], [a>2]->[z]`

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -199,10 +199,12 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
 /**
  * Instances of `<script type="module">` generate synthetic entrypoints in the
  * depsIndex and are treated as entrypoints during the initial phase of
- * `generateBundles`.  Before returning the resulting bundles, any bundle which
- * provides dependencies to a single entrypoint of this type (aka a single
- * entrypoint sub-bundle) are merged back into the bundle for the html
- * containing the script tag, using this function.
+ * `generateBundles`.  Before handing bundles to the strategy function, if
+ * script inlining is enabled, any bundle which provides dependencies to a
+ * single synthetic entrypoint of this type (aka a single entrypoint sub-bundle)
+ * are merged back into the bundle for the HTML containing the script tag, by
+ * use of this function, which performs the merge(s) in-place to the provided
+ * array of bundles.
  *
  * For example, the following bundles:
  *   `[a]->[a], [a>1]->[x], [a>1,a>2]->[y], [a>2]->[z]`

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -193,7 +193,6 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
     bundle.files.add(dep);
   }
 
-  mergeSingleEntrypointSubBundles(bundles);
   return bundles;
 }
 
@@ -211,7 +210,7 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
  * Would be merged into the following set of bundles:
  *   `[a]->[a,x,z], [a>1,a>2]->[y]`
  */
-function mergeSingleEntrypointSubBundles(bundles: Bundle[]) {
+export function mergeSingleEntrypointSubBundles(bundles: Bundle[]) {
   for (const subBundle of [...bundles]) {
     if (subBundle.entrypoints.size === 1) {
       const entrypointUrl = [...subBundle.entrypoints][0];

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -15,8 +15,7 @@
 import * as clone from 'clone';
 import {PackageRelativeUrl, ResolvedUrl, UrlResolver} from 'polymer-analyzer';
 
-import {getSuperBundleUrl} from './deps-index';
-import {getFileExtension} from './url-utils';
+import {getSubBundleFileExtension, getSuperBundleUrl} from './deps-index';
 import {uniq} from './utils';
 
 /**
@@ -189,8 +188,8 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
         bundles.find((bundle) => setEquals(entrypoints, bundle.entrypoints));
 
     if (!bundle) {
-      const type = [...entrypoints].every(
-                       (e) => !!e.match(/>/) || getFileExtension(e) === '.js') ?
+      const type =
+          [...entrypoints].some((e) => getSubBundleFileExtension(e) === '.js') ?
           'es6-module' :
           'html-fragment';
       bundle = new Bundle(type, entrypoints);

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -14,6 +14,8 @@
 
 import * as clone from 'clone';
 import {PackageRelativeUrl, ResolvedUrl, UrlResolver} from 'polymer-analyzer';
+
+import {getSuperBundleUrl} from './deps-index';
 import {uniq} from './utils';
 
 /**
@@ -216,8 +218,7 @@ export function mergeSingleEntrypointSubBundles(bundles: Bundle[]) {
   for (const subBundle of [...bundles]) {
     if (subBundle.entrypoints.size === 1) {
       const entrypointUrl = [...subBundle.entrypoints][0];
-      const superBundleUrl =
-          entrypointUrl.replace(/>[^>]+$/, '') as ResolvedUrl;
+      const superBundleUrl = getSuperBundleUrl(entrypointUrl);
 
       // If the entrypoint URL is the same as the super bundle URL then the
       // entrypoint URL has not changed and did not represent a sub bundle, so

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -427,17 +427,17 @@ export function mergeMatchingBundles(
   const newBundles = Array.from(bundles);
   const bundlesToMerge = newBundles.filter(predicate);
 
-  const types = [...new Set(bundlesToMerge.map((b) => b.type))].sort();
-  types.forEach((bundleType) => {
-    const bundlesToMergeForType =
-        bundlesToMerge.filter((b) => b.type === bundleType);
-    if (bundlesToMergeForType.length > 1) {
-      for (const bundle of bundlesToMergeForType) {
-        newBundles.splice(newBundles.indexOf(bundle), 1);
-      }
-      newBundles.push(mergeBundles(bundlesToMergeForType));
-    }
-  });
+  [...new Set(bundlesToMerge.map((b) => b.type))].sort().forEach(
+      (bundleType) => {
+        const bundlesToMergeForType =
+            bundlesToMerge.filter((b) => b.type === bundleType);
+        if (bundlesToMergeForType.length > 1) {
+          for (const bundle of bundlesToMergeForType) {
+            newBundles.splice(newBundles.indexOf(bundle), 1);
+          }
+          newBundles.push(mergeBundles(bundlesToMergeForType));
+        }
+      });
   return newBundles;
 }
 

--- a/src/bundle-manifest.ts
+++ b/src/bundle-manifest.ts
@@ -16,6 +16,7 @@ import * as clone from 'clone';
 import {PackageRelativeUrl, ResolvedUrl, UrlResolver} from 'polymer-analyzer';
 
 import {getSuperBundleUrl} from './deps-index';
+import {getFileExtension} from './url-utils';
 import {uniq} from './utils';
 
 /**
@@ -188,7 +189,8 @@ export function generateBundles(depsIndex: TransitiveDependenciesMap):
         bundles.find((bundle) => setEquals(entrypoints, bundle.entrypoints));
 
     if (!bundle) {
-      const type = [...entrypoints].some((e) => !!e.match(/>/)) ?
+      const type = [...entrypoints].every(
+                       (e) => !!e.match(/>/) || getFileExtension(e) === '.js') ?
           'es6-module' :
           'html-fragment';
       bundle = new Bundle(type, entrypoints);

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -156,8 +156,7 @@ export class Bundler {
   async generateManifest(entrypoints: ResolvedUrl[]): Promise<BundleManifest> {
     const dependencyIndex =
         await depsIndexLib.buildDepsIndex(entrypoints, this.analyzer);
-    let bundles =
-        bundleManifestLib.generateBundles(dependencyIndex.entrypointToDeps);
+    let bundles = bundleManifestLib.generateBundles(dependencyIndex);
     this._filterExcludesFromBundles(bundles);
     bundles = this.strategy(bundles);
     return new BundleManifest(bundles, this.urlMapper);

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -157,6 +157,11 @@ export class Bundler {
     const dependencyIndex =
         await depsIndexLib.buildDepsIndex(entrypoints, this.analyzer);
     let bundles = bundleManifestLib.generateBundles(dependencyIndex);
+    // Merge single-entrypoint sub-bundles into their containing documents so
+    // that inlining code can knows which module scripts can be inlined.
+    if (this.enableScriptInlining) {
+      bundleManifestLib.mergeSingleEntrypointSubBundles(bundles);
+    }
     this._filterExcludesFromBundles(bundles);
     bundles = this.strategy(bundles);
     return new BundleManifest(bundles, this.urlMapper);

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -11,33 +11,62 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
+import * as dom5 from 'dom5';
 import {Analyzer, Document, ResolvedUrl} from 'polymer-analyzer';
+
 import {getAnalysisDocument} from './analyzer-utils';
 
-export interface DepsIndex {
-  // An index of entrypoint -> html dependencies
-  entrypointToDeps: Map<ResolvedUrl, Set<ResolvedUrl>>;
-}
+// An index of entrypoint -> html dependencies
+export type DepsIndex = Map<ResolvedUrl, Set<ResolvedUrl>>;
+
+type ScriptImport = {
+  scriptId: string,
+  url: ResolvedUrl,
+  imported: Document,
+};
 
 type DependencyMapEntry = {
   // All dependencies of the document
   deps: Set<ResolvedUrl>,
   // Eagerly loaded dependencies of the document
   eagerDeps: Set<ResolvedUrl>,
-  // All imports defined with `<link rel="lazy-import">`
+  // All imports defined with `<link rel="lazy-import">` or with dynamic ES
+  // module import syntax like `import().then()`
   lazyImports: Set<ResolvedUrl>,
+  // All imports defined with `<script type="module" src="...">` or as import
+  // statements within a `<script type="module">...</script>`
+  scriptImports: Set<ScriptImport>,
 };
 
 /**
  * For a given document, return a set of transitive dependencies, including
  * all eagerly-loaded dependencies and lazy html imports encountered.
  */
-function getHtmlDependencies(document: Document): DependencyMapEntry {
+function getDependencies(document: Document): DependencyMapEntry {
   const deps = new Set<ResolvedUrl>();
   const eagerDeps = new Set<ResolvedUrl>();
   const lazyImports = new Set<ResolvedUrl>();
-  _getHtmlDependencies(document, true, deps, eagerDeps, lazyImports);
-  return {deps, eagerDeps, lazyImports};
+  const scriptImports = new Set<ScriptImport>();
+  _getDependencies(document, true, deps, eagerDeps, lazyImports, scriptImports);
+  return {deps, eagerDeps, lazyImports, scriptImports};
+}
+
+function _getDependencies(
+    document: Document,
+    viaEager: boolean,
+    visited: Set<ResolvedUrl>,
+    visitedEager: Set<ResolvedUrl>,
+    lazyImports: Set<ResolvedUrl>,
+    scriptImports: Set<ScriptImport>) {
+  if (document.kinds.has('html-document')) {
+    _getHtmlDependencies(
+        document, viaEager, visited, visitedEager, lazyImports, scriptImports);
+  }
+
+  if (document.kinds.has('js-document')) {
+    _getJavaScriptDependencies(
+        document, viaEager, visited, visitedEager, lazyImports, scriptImports);
+  }
 }
 
 function _getHtmlDependencies(
@@ -45,7 +74,28 @@ function _getHtmlDependencies(
     viaEager: boolean,
     visited: Set<ResolvedUrl>,
     visitedEager: Set<ResolvedUrl>,
-    lazyImports: Set<ResolvedUrl>) {
+    lazyImports: Set<ResolvedUrl>,
+    scriptImports: Set<ScriptImport>) {
+  // We have to wind through the html scripts, but we don't treat html scripts
+  // AS imports.
+  let htmlScriptCount = 0;
+  const htmlScripts = document.getFeatures(
+      {kind: 'html-script', imported: false, externalPackages: true});
+  for (const htmlScript of htmlScripts) {
+    ++htmlScriptCount;
+    // TODO(usergenic): Update polymer-analyzer to discriminate between
+    // `<script>` and `<script type=module>` instead of using dom5 here to
+    // inspect AST.
+    const isModule = dom5.getAttribute(htmlScript.astNode, 'type') === 'module';
+    if (!isModule) {
+      continue;
+    }
+    const url = htmlScript.document.url;
+    const scriptId = `external-module-${htmlScriptCount}`;
+    scriptImports.add({scriptId, url, imported: htmlScript.document});
+    continue;
+  }
+
   const htmlImports = document.getFeatures(
       {kind: 'html-import', imported: false, externalPackages: true});
   for (const htmlImport of htmlImports) {
@@ -56,7 +106,7 @@ function _getHtmlDependencies(
     if (visitedEager.has(importUrl)) {
       continue;
     }
-    const isEager = viaEager && !htmlImport.lazy;
+    const isEager = viaEager && !lazyImports.has(importUrl);
     if (isEager) {
       visitedEager.add(importUrl);
       // In this case we've visited a node eagerly for the first time,
@@ -66,8 +116,68 @@ function _getHtmlDependencies(
       continue;
     }
     visited.add(importUrl);
-    _getHtmlDependencies(
-        htmlImport.document, isEager, visited, visitedEager, lazyImports);
+    _getDependencies(
+        htmlImport.document,
+        isEager,
+        visited,
+        visitedEager,
+        lazyImports,
+        scriptImports);
+  }
+
+  const jsDocuments = [
+    ...document.getFeatures(
+        {kind: 'js-document', imported: false, externalPackages: true})
+  ].filter((d) => d.kinds.has('inline-document'));
+  for (const jsDocument of jsDocuments) {
+    if (jsDocument.parsedDocument.parsedAsSourceType === 'module') {
+      ++htmlScriptCount;
+      const url = jsDocument.parsedDocument.url;
+      const scriptId = `inline-module-${htmlScriptCount}`;
+      scriptImports.add({scriptId, url, imported: jsDocument});
+    }
+  }
+}
+
+function _getJavaScriptDependencies(
+    document: Document,
+    viaEager: boolean,
+    visited: Set<ResolvedUrl>,
+    visitedEager: Set<ResolvedUrl>,
+    lazyImports: Set<ResolvedUrl>,
+    scriptImports: Set<ScriptImport>) {
+  const jsImports = document.getFeatures({
+    kind: 'js-import',
+    imported: false,
+    externalPackages: true,
+    excludeBackreferences: true,
+  });
+  for (const jsImport of jsImports) {
+    const importUrl = jsImport.document.url;
+    if (jsImport.lazy) {
+      lazyImports.add(importUrl);
+    }
+    if (visitedEager.has(importUrl)) {
+      continue;
+    }
+
+    const isEager = viaEager && !lazyImports.has(importUrl);
+    if (isEager) {
+      visitedEager.add(importUrl);
+      // In this case we've visited a node eagerly for the first time,
+      // so recurse
+    } else if (visited.has(importUrl)) {
+      // In this case we're seeing a node lazily again, so don't recurse
+      continue;
+    }
+    visited.add(importUrl);
+    _getDependencies(
+        jsImport.document,
+        isEager,
+        visited,
+        visitedEager,
+        lazyImports,
+        scriptImports);
   }
 }
 
@@ -81,28 +191,40 @@ function _getHtmlDependencies(
  */
 export async function buildDepsIndex(
     entrypoints: ResolvedUrl[], analyzer: Analyzer): Promise<DepsIndex> {
-  const depsIndex = {
-    entrypointToDeps: new Map<ResolvedUrl, Set<ResolvedUrl>>()
-  };
+  const depsIndex = new Map<ResolvedUrl, Set<ResolvedUrl>>();
   const analysis = await analyzer.analyze(entrypoints);
   const allEntrypoints = new Set<ResolvedUrl>(entrypoints);
+  const inlineDocuments = new Map<ResolvedUrl, Document>();
 
   // Note: the following iteration takes place over a Set which may be added
   // to from within the loop.
   for (const entrypoint of allEntrypoints) {
     try {
-      const document = getAnalysisDocument(analysis, entrypoint);
-      const deps = getHtmlDependencies(document);
-      depsIndex.entrypointToDeps.set(
-          entrypoint, new Set([entrypoint, ...deps.eagerDeps]));
+      const document = inlineDocuments.has(entrypoint) ?
+          inlineDocuments.get(entrypoint)! :
+          getAnalysisDocument(analysis, entrypoint);
+      const deps = getDependencies(document);
+      depsIndex.set(entrypoint, new Set([
+                      ...(document.isInline ? [] : [document.url]),
+                      ...deps.eagerDeps
+                    ]));
+
       // Add lazy imports to the set of all entrypoints, which supports
       // recursive
       for (const dep of deps.lazyImports) {
         allEntrypoints.add(dep);
       }
+
+      // Add script
+      for (const {scriptId, imported} of deps.scriptImports) {
+        const syntheticUrl = `${document.url}>${scriptId}` as ResolvedUrl;
+        allEntrypoints.add(syntheticUrl);
+        inlineDocuments.set(syntheticUrl, imported);
+      }
     } catch (e) {
       console.warn(e.message);
     }
   }
+
   return depsIndex;
 }

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -54,9 +54,9 @@ export async function buildDepsIndex(
 
       // Add script
       for (const [id, imported] of deps.moduleScriptImports) {
-        const syntheticUrl = `${document.url}>${id}` as ResolvedUrl;
-        allEntrypoints.add(syntheticUrl);
-        inlineDocuments.set(syntheticUrl, imported);
+        const subBundleUrl = getSubBundleUrl(document.url, id);
+        allEntrypoints.add(subBundleUrl);
+        inlineDocuments.set(subBundleUrl, imported);
       }
     } catch (e) {
       console.warn(e.message);
@@ -64,6 +64,24 @@ export async function buildDepsIndex(
   }
 
   return depsIndex;
+}
+
+/**
+ * Constructs a ResolvedUrl to identify a sub bundle, which is a concatenation
+ * of the super bundle or containing file's URL and an id for the sub-bundle.
+ */
+export function getSubBundleUrl(
+    superBundleUrl: ResolvedUrl, id: string): ResolvedUrl {
+  return `${superBundleUrl}>${id}` as ResolvedUrl;
+}
+
+/**
+ * Strips the sub-bundle id off the end of a URL to return the super bundle or
+ * containing file's URL.  If there is no sub-bundle id on the provided URL, the
+ * result is essentially a NOOP, since nothing will have been stripped.
+ */
+export function getSuperBundleUrl(subBundleUrl: string): ResolvedUrl {
+  return subBundleUrl.replace(/>[^>]+$/, '') as ResolvedUrl;
 }
 
 type DependencyMapEntry = {

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -16,7 +16,7 @@ import {JavaScriptDocument} from 'polymer-analyzer/lib/javascript/javascript-doc
 
 import {getAnalysisDocument} from './analyzer-utils';
 
-// An index of entrypoint -> html dependencies
+// An index of entrypoint -> dependencies
 export type DepsIndex = Map<ResolvedUrl, Set<ResolvedUrl>>;
 
 /**

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -15,7 +15,6 @@ import {Analyzer, Document, Import, ResolvedUrl} from 'polymer-analyzer';
 import {JavaScriptDocument} from 'polymer-analyzer/lib/javascript/javascript-document';
 
 import {getAnalysisDocument} from './analyzer-utils';
-import {getFileExtension} from './url-utils';
 
 // An index of entrypoint -> dependencies
 export type DepsIndex = Map<ResolvedUrl, Set<ResolvedUrl>>;
@@ -78,15 +77,6 @@ export async function buildDepsIndex(
 export function getSubBundleUrl(
     superBundleUrl: ResolvedUrl, id: string): ResolvedUrl {
   return `${superBundleUrl}>${id}` as ResolvedUrl;
-}
-
-/**
- * Returns the file extension for the URL.  If the URL given is a compound
- * `>`-joined string representing a sub-bundle, the extension will come from the
- * last segment, which describes the type of content in the sub-bundle.
- */
-export function getSubBundleFileExtension(url: string): string {
-  return getFileExtension(url.split('>').pop()!);
 }
 
 /**
@@ -169,7 +159,7 @@ function getDependencies(
       const relativeUrl =
           analyzer.urlResolver.relative(document.url, htmlScript.document.url);
       moduleScriptImports.set(
-          `external-module-${++externalModuleCount}>${relativeUrl}`,
+          `external#${++externalModuleCount}>${relativeUrl}>es6-module`,
           htmlScript.document);
     }
   }
@@ -183,7 +173,7 @@ function getDependencies(
                     d.parsedDocument.parsedAsSourceType === 'module');
     for (const jsDocument of jsDocuments) {
       moduleScriptImports.set(
-          `inline-module-${++jsDocumentCount}.js`, jsDocument);
+          `inline#${++jsDocumentCount}>es6-module`, jsDocument);
     }
   }
 

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -11,175 +11,12 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import * as dom5 from 'dom5';
 import {Analyzer, Document, ResolvedUrl} from 'polymer-analyzer';
-
+import {JavaScriptDocument} from 'polymer-analyzer/lib/javascript/javascript-document';
 import {getAnalysisDocument} from './analyzer-utils';
 
 // An index of entrypoint -> html dependencies
 export type DepsIndex = Map<ResolvedUrl, Set<ResolvedUrl>>;
-
-type ScriptImport = {
-  scriptId: string,
-  url: ResolvedUrl,
-  imported: Document,
-};
-
-type DependencyMapEntry = {
-  // All dependencies of the document
-  deps: Set<ResolvedUrl>,
-  // Eagerly loaded dependencies of the document
-  eagerDeps: Set<ResolvedUrl>,
-  // All imports defined with `<link rel="lazy-import">` or with dynamic ES
-  // module import syntax like `import().then()`
-  lazyImports: Set<ResolvedUrl>,
-  // All imports defined with `<script type="module" src="...">` or as import
-  // statements within a `<script type="module">...</script>`
-  scriptImports: Set<ScriptImport>,
-};
-
-/**
- * For a given document, return a set of transitive dependencies, including
- * all eagerly-loaded dependencies and lazy html imports encountered.
- */
-function getDependencies(document: Document): DependencyMapEntry {
-  const deps = new Set<ResolvedUrl>();
-  const eagerDeps = new Set<ResolvedUrl>();
-  const lazyImports = new Set<ResolvedUrl>();
-  const scriptImports = new Set<ScriptImport>();
-  _getDependencies(document, true, deps, eagerDeps, lazyImports, scriptImports);
-  return {deps, eagerDeps, lazyImports, scriptImports};
-}
-
-function _getDependencies(
-    document: Document,
-    viaEager: boolean,
-    visited: Set<ResolvedUrl>,
-    visitedEager: Set<ResolvedUrl>,
-    lazyImports: Set<ResolvedUrl>,
-    scriptImports: Set<ScriptImport>) {
-  if (document.kinds.has('html-document')) {
-    _getHtmlDependencies(
-        document, viaEager, visited, visitedEager, lazyImports, scriptImports);
-  }
-
-  if (document.kinds.has('js-document')) {
-    _getJavaScriptDependencies(
-        document, viaEager, visited, visitedEager, lazyImports, scriptImports);
-  }
-}
-
-function _getHtmlDependencies(
-    document: Document,
-    viaEager: boolean,
-    visited: Set<ResolvedUrl>,
-    visitedEager: Set<ResolvedUrl>,
-    lazyImports: Set<ResolvedUrl>,
-    scriptImports: Set<ScriptImport>) {
-  // We have to wind through the html scripts, but we don't treat html scripts
-  // AS imports.
-  let htmlScriptCount = 0;
-  const htmlScripts = document.getFeatures(
-      {kind: 'html-script', imported: false, externalPackages: true});
-  for (const htmlScript of htmlScripts) {
-    ++htmlScriptCount;
-    // TODO(usergenic): Update polymer-analyzer to discriminate between
-    // `<script>` and `<script type=module>` instead of using dom5 here to
-    // inspect AST.
-    const isModule = dom5.getAttribute(htmlScript.astNode, 'type') === 'module';
-    if (!isModule) {
-      continue;
-    }
-    const url = htmlScript.document.url;
-    const scriptId = `external-module-${htmlScriptCount}`;
-    scriptImports.add({scriptId, url, imported: htmlScript.document});
-    continue;
-  }
-
-  const htmlImports = document.getFeatures(
-      {kind: 'html-import', imported: false, externalPackages: true});
-  for (const htmlImport of htmlImports) {
-    const importUrl = htmlImport.document.url;
-    if (htmlImport.lazy) {
-      lazyImports.add(importUrl);
-    }
-    if (visitedEager.has(importUrl)) {
-      continue;
-    }
-    const isEager = viaEager && !lazyImports.has(importUrl);
-    if (isEager) {
-      visitedEager.add(importUrl);
-      // In this case we've visited a node eagerly for the first time,
-      // so recurse
-    } else if (visited.has(importUrl)) {
-      // In this case we're seeing a node lazily again, so don't recurse
-      continue;
-    }
-    visited.add(importUrl);
-    _getDependencies(
-        htmlImport.document,
-        isEager,
-        visited,
-        visitedEager,
-        lazyImports,
-        scriptImports);
-  }
-
-  const jsDocuments = [
-    ...document.getFeatures(
-        {kind: 'js-document', imported: false, externalPackages: true})
-  ].filter((d) => d.kinds.has('inline-document'));
-  for (const jsDocument of jsDocuments) {
-    if (jsDocument.parsedDocument.parsedAsSourceType === 'module') {
-      ++htmlScriptCount;
-      const url = jsDocument.parsedDocument.url;
-      const scriptId = `inline-module-${htmlScriptCount}`;
-      scriptImports.add({scriptId, url, imported: jsDocument});
-    }
-  }
-}
-
-function _getJavaScriptDependencies(
-    document: Document,
-    viaEager: boolean,
-    visited: Set<ResolvedUrl>,
-    visitedEager: Set<ResolvedUrl>,
-    lazyImports: Set<ResolvedUrl>,
-    scriptImports: Set<ScriptImport>) {
-  const jsImports = document.getFeatures({
-    kind: 'js-import',
-    imported: false,
-    externalPackages: true,
-    excludeBackreferences: true,
-  });
-  for (const jsImport of jsImports) {
-    const importUrl = jsImport.document.url;
-    if (jsImport.lazy) {
-      lazyImports.add(importUrl);
-    }
-    if (visitedEager.has(importUrl)) {
-      continue;
-    }
-
-    const isEager = viaEager && !lazyImports.has(importUrl);
-    if (isEager) {
-      visitedEager.add(importUrl);
-      // In this case we've visited a node eagerly for the first time,
-      // so recurse
-    } else if (visited.has(importUrl)) {
-      // In this case we're seeing a node lazily again, so don't recurse
-      continue;
-    }
-    visited.add(importUrl);
-    _getDependencies(
-        jsImport.document,
-        isEager,
-        visited,
-        visitedEager,
-        lazyImports,
-        scriptImports);
-  }
-}
 
 /**
  * Analyzes all entrypoints and determines each of their transitive
@@ -216,8 +53,8 @@ export async function buildDepsIndex(
       }
 
       // Add script
-      for (const {scriptId, imported} of deps.scriptImports) {
-        const syntheticUrl = `${document.url}>${scriptId}` as ResolvedUrl;
+      for (const [id, imported] of deps.moduleScriptImports) {
+        const syntheticUrl = `${document.url}>${id}` as ResolvedUrl;
         allEntrypoints.add(syntheticUrl);
         inlineDocuments.set(syntheticUrl, imported);
       }
@@ -227,4 +64,131 @@ export async function buildDepsIndex(
   }
 
   return depsIndex;
+}
+
+type DependencyMapEntry = {
+  // All dependencies of the document
+  deps: Set<ResolvedUrl>,
+  // Eagerly loaded dependencies of the document
+  eagerDeps: Set<ResolvedUrl>,
+  // All imports defined with `<link rel="lazy-import">` or with dynamic ES
+  // module import syntax like `import().then()`
+  lazyImports: Set<ResolvedUrl>,
+  // All imports defined with `<script type="module" src="...">` or as import
+  // statements within a `<script type="module">...</script>`
+  moduleScriptImports: Map<string, Document>,
+};
+
+/**
+ * These are the options included in every `Document#getFeatures` call, DRY'd up
+ * here for brevity and consistency.
+ */
+const getFeaturesOptions = {
+  imported: false,
+  externalPackages: true,
+  excludeBackreferences: true,
+};
+
+/**
+ * For a given document, return a set of transitive dependencies, including
+ * all eagerly-loaded dependencies and lazy html imports encountered.
+ */
+function getDependencies(document: Document): DependencyMapEntry {
+  const deps = new Set<ResolvedUrl>();
+  const eagerDeps = new Set<ResolvedUrl>();
+  const lazyImports = new Set<ResolvedUrl>();
+  const moduleScriptImports = new Map<string, Document>();
+  _getDependencies(document, true);
+  return {deps, eagerDeps, lazyImports, moduleScriptImports};
+
+  function _getDependencies(document: Document, viaEager: boolean) {
+    if (document.kinds.has('html-document')) {
+      _getHtmlExternalModuleDependencies(document, viaEager);
+      _getHtmlInlineModuleDependencies(document, viaEager);
+      _getHtmlImportDependencies(document, viaEager);
+    }
+
+    if (document.kinds.has('js-document')) {
+      _getJavaScriptModuleDependencies(document, viaEager);
+    }
+  }
+
+  function _getHtmlExternalModuleDependencies(
+      document: Document, viaEager: boolean) {
+    let externalModuleCount = 0;
+    const htmlScripts =
+        [...document.getFeatures({kind: 'html-script', ...getFeaturesOptions})]
+            .filter(
+                (s) => (s.document.parsedDocument as JavaScriptDocument)
+                           .parsedAsSourceType === 'module');
+    for (const htmlScript of htmlScripts) {
+      moduleScriptImports.set(
+          `external-module:${++externalModuleCount}`, htmlScript.document);
+    }
+  }
+
+  function _getHtmlImportDependencies(document: Document, viaEager: boolean) {
+    const htmlImports =
+        document.getFeatures({kind: 'html-import', ...getFeaturesOptions});
+    for (const htmlImport of htmlImports) {
+      const importUrl = htmlImport.document.url;
+      if (htmlImport.lazy) {
+        lazyImports.add(importUrl);
+      }
+      if (eagerDeps.has(importUrl)) {
+        continue;
+      }
+      const isEager = viaEager && !lazyImports.has(importUrl);
+      if (isEager) {
+        eagerDeps.add(importUrl);
+        // In this case we've visited a node eagerly for the first time,
+        // so recurse
+      } else if (deps.has(importUrl)) {
+        // In this case we're seeing a node lazily again, so don't recurse
+        continue;
+      }
+      deps.add(importUrl);
+      _getDependencies(htmlImport.document, isEager);
+    }
+  }
+
+  function _getHtmlInlineModuleDependencies(
+      document: Document, viaEager: boolean) {
+    let jsDocumentCount = 0;
+    const jsDocuments =
+        [...document.getFeatures({kind: 'js-document', ...getFeaturesOptions})]
+            .filter(
+                (d) => d.kinds.has('inline-document') &&
+                    d.parsedDocument.parsedAsSourceType === 'module');
+    for (const jsDocument of jsDocuments) {
+      moduleScriptImports.set(`inline-module:${++jsDocumentCount}`, jsDocument);
+    }
+  }
+
+  function _getJavaScriptModuleDependencies(
+      document: Document, viaEager: boolean) {
+    const jsImports =
+        document.getFeatures({kind: 'js-import', ...getFeaturesOptions});
+    for (const jsImport of jsImports) {
+      const importUrl = jsImport.document.url;
+      if (jsImport.lazy) {
+        lazyImports.add(importUrl);
+      }
+      if (eagerDeps.has(importUrl)) {
+        continue;
+      }
+
+      const isEager = viaEager && !lazyImports.has(importUrl);
+      if (isEager) {
+        eagerDeps.add(importUrl);
+        // In this case we've visited a node eagerly for the first time,
+        // so recurse
+      } else if (deps.has(importUrl)) {
+        // In this case we're seeing a node lazily again, so don't recurse
+        continue;
+      }
+      deps.add(importUrl);
+      _getDependencies(jsImport.document, isEager);
+    }
+  }
 }

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -83,7 +83,7 @@ export function getSubBundleUrl(
 /**
  * Returns the file extension for the URL.  If the URL given is a compound
  * `>`-joined string representing a sub-bundle, the extension will come from the
- * last segment, which describes the type of the content.
+ * last segment, which describes the type of content in the sub-bundle.
  */
 export function getSubBundleFileExtension(url: string): string {
   return getFileExtension(url.split('>').pop()!);

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -47,6 +47,10 @@ suite('BundleManifest', () => {
     return `[${entrypoints}]->[${files}]`;
   }
 
+  function serializeWithType(bundle: Bundle): string {
+    return serializeBundle(bundle) + `.${bundle.type}`;
+  }
+
   suite('mergeBundles()', () => {
 
     test('can not work unless at least one Bundle provided', () => {
@@ -429,6 +433,35 @@ suite('BundleManifest', () => {
               '[B,D]->[6,D]'
             ]);
       });
+    });
+  });
+
+  suite('Bundle types', () => {
+    test('inferred properly from resolved URLs of entrypoints', () => {
+      const depsIndex: TransitiveDependenciesMap = new Map();
+      depsIndex.set(r`page1.html`, new Set([r`page1.html`]));
+      depsIndex.set(
+          r`page1.html>inline-module-1`,
+          new Set([r`shared-1.js`, r`shared-2.js`]));
+      depsIndex.set(
+          r`page1.html>inline-module-2`,
+          new Set([r`shared-1.js`, r`shared-2.js`]));
+      depsIndex.set(r`page2.html`, new Set([r`page2.html`]));
+      depsIndex.set(
+          r`page2.html>inline-module-1`,
+          new Set([r`page2-only.js`, r`shared-2.js`]));
+      depsIndex.set(r`dynamic-import.js`, new Set([r`dynamic-import.js`]));
+      const expected = [
+        '[dynamic-import.js]->[dynamic-import.js].es6-module',
+        '[page1.html>inline-module-1,page1.html>inline-module-2,page2.html>inline-module-1]->[shared-2.js].es6-module',
+        '[page1.html>inline-module-1,page1.html>inline-module-2]->[shared-1.js].es6-module',
+        '[page1.html]->[page1.html].html-fragment',
+        '[page2.html>inline-module-1]->[page2-only.js].es6-module',
+        '[page2.html]->[page2.html].html-fragment',
+      ];
+      const bundles = generateBundles(depsIndex);
+      const serializedBundles = bundles.map(serializeWithType).sort();
+      assert.deepEqual(serializedBundles, expected);
     });
   });
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -441,22 +441,22 @@ suite('BundleManifest', () => {
       const depsIndex: TransitiveDependenciesMap = new Map();
       depsIndex.set(r`page1.html`, new Set([r`page1.html`]));
       depsIndex.set(
-          r`page1.html>inline-module-1`,
+          r`page1.html>inline-module-1.js`,
           new Set([r`shared-1.js`, r`shared-2.js`]));
       depsIndex.set(
-          r`page1.html>inline-module-2`,
+          r`page1.html>inline-module-2.js`,
           new Set([r`shared-1.js`, r`shared-2.js`]));
       depsIndex.set(r`page2.html`, new Set([r`page2.html`]));
       depsIndex.set(
-          r`page2.html>inline-module-1`,
+          r`page2.html>inline-module-1.js`,
           new Set([r`page2-only.js`, r`shared-2.js`]));
       depsIndex.set(r`dynamic-import.js`, new Set([r`dynamic-import.js`]));
       const expected = [
         '[dynamic-import.js]->[dynamic-import.js].es6-module',
-        '[page1.html>inline-module-1,page1.html>inline-module-2,page2.html>inline-module-1]->[shared-2.js].es6-module',
-        '[page1.html>inline-module-1,page1.html>inline-module-2]->[shared-1.js].es6-module',
+        '[page1.html>inline-module-1.js,page1.html>inline-module-2.js,page2.html>inline-module-1.js]->[shared-2.js].es6-module',
+        '[page1.html>inline-module-1.js,page1.html>inline-module-2.js]->[shared-1.js].es6-module',
         '[page1.html]->[page1.html].html-fragment',
-        '[page2.html>inline-module-1]->[page2-only.js].es6-module',
+        '[page2.html>inline-module-1.js]->[page2-only.js].es6-module',
         '[page2.html]->[page2.html].html-fragment',
       ];
       const bundles = generateBundles(depsIndex);

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -18,7 +18,7 @@ import * as chai from 'chai';
 import {ResolvedUrl} from 'polymer-analyzer';
 import {resolvedUrl as r} from 'polymer-analyzer/lib/test/test-utils';
 
-import {Bundle, BundleManifest, composeStrategies, generateBundles, generateCountingSharedBundleUrlMapper, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedBundleUrlMapper, generateSharedDepsMergeStrategy, generateShellMergeStrategy, mergeBundles, TransitiveDependenciesMap} from '../bundle-manifest';
+import {Bundle, BundleManifest, composeStrategies, generateBundles, generateCountingSharedBundleUrlMapper, generateEagerMergeStrategy, generateMatchMergeStrategy, generateSharedBundleUrlMapper, generateSharedDepsMergeStrategy, generateShellMergeStrategy, mergeBundles, mergeSingleEntrypointSubBundles, TransitiveDependenciesMap} from '../bundle-manifest';
 
 chai.config.showDiff = true;
 
@@ -134,14 +134,20 @@ suite('BundleManifest', () => {
       depsIndex.set(r`B`, new Set([r`B`]));
       depsIndex.set(r`B>1`, new Set([r`Y`]));
 
-      const bundles = generateBundles(depsIndex).map(serializeBundle).sort();
-      assert.deepEqual(
-          bundles,
-          [
-            '[A>2,B>1]->[Y]',  //
-            '[A]->[A,X]',
-            '[B]->[B]',
-          ]);
+      const bundles = generateBundles(depsIndex);
+      assert.deepEqual(bundles.map(serializeBundle).sort(), [
+        '[A>1]->[X]',
+        '[A>2,B>1]->[Y]',
+        '[A]->[A]',
+        '[B]->[B]',
+      ]);
+
+      mergeSingleEntrypointSubBundles(bundles);
+      assert.deepEqual(bundles.map(serializeBundle).sort(), [
+        '[A>2,B>1]->[Y]',
+        '[A]->[A,X]',
+        '[B]->[B]',
+      ]);
     });
   });
 

--- a/src/test/bundle-manifest_test.ts
+++ b/src/test/bundle-manifest_test.ts
@@ -441,22 +441,22 @@ suite('BundleManifest', () => {
       const depsIndex: TransitiveDependenciesMap = new Map();
       depsIndex.set(r`page1.html`, new Set([r`page1.html`]));
       depsIndex.set(
-          r`page1.html>inline-module-1.js`,
+          r`page1.html>inline#1>es6-module`,
           new Set([r`shared-1.js`, r`shared-2.js`]));
       depsIndex.set(
-          r`page1.html>inline-module-2.js`,
+          r`page1.html>inline#2>es6-module`,
           new Set([r`shared-1.js`, r`shared-2.js`]));
       depsIndex.set(r`page2.html`, new Set([r`page2.html`]));
       depsIndex.set(
-          r`page2.html>inline-module-1.js`,
+          r`page2.html>inline#1>es6-module`,
           new Set([r`page2-only.js`, r`shared-2.js`]));
       depsIndex.set(r`dynamic-import.js`, new Set([r`dynamic-import.js`]));
       const expected = [
         '[dynamic-import.js]->[dynamic-import.js].es6-module',
-        '[page1.html>inline-module-1.js,page1.html>inline-module-2.js,page2.html>inline-module-1.js]->[shared-2.js].es6-module',
-        '[page1.html>inline-module-1.js,page1.html>inline-module-2.js]->[shared-1.js].es6-module',
+        '[page1.html>inline#1>es6-module,page1.html>inline#2>es6-module,page2.html>inline#1>es6-module]->[shared-2.js].es6-module',
+        '[page1.html>inline#1>es6-module,page1.html>inline#2>es6-module]->[shared-1.js].es6-module',
         '[page1.html]->[page1.html].html-fragment',
-        '[page2.html>inline-module-1.js]->[page2-only.js].es6-module',
+        '[page2.html>inline#1>es6-module]->[page2-only.js].es6-module',
         '[page2.html]->[page2.html].html-fragment',
       ];
       const bundles = generateBundles(depsIndex);

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -100,9 +100,10 @@ suite('Bundler', () => {
 
     test('URLs for inlined HTML imports are recorded in Bundle', async () => {
       await bundle(inputPath);
-      assert.deepEqual(
-          [...documentBundle.inlinedHtmlImports],
-          [resolve('imports/simple-import.html')]);
+      assert.deepEqual([...documentBundle.inlinedHtmlImports], [
+        resolve('imports/simple-import.html'),
+        resolve('imports/another-simple-import.html'),
+      ]);
     });
 
     test('imports removed', async () => {
@@ -118,7 +119,10 @@ suite('Bundler', () => {
     test('imports were deduplicated', async () => {
       assert.equal(
           dom5.queryAll(
-                  (await bundle(inputPath)).ast, preds.hasTagName('dom-module'))
+                  (await bundle(inputPath)).ast,
+                  preds.AND(
+                      preds.hasAttrValue('id', 'my-element'),
+                      preds.hasTagName('dom-module')))
               .length,
           1);
     });
@@ -176,7 +180,10 @@ suite('Bundler', () => {
                 new Bundle(
                     'html-fragment',
                     new Set(),  //
-                    new Set([resolve('imports/simple-import.html')]))
+                    new Set([
+                      resolve('imports/simple-import.html'),
+                      resolve('imports/another-simple-import.html'),
+                    ]))
               ];
             }
           });
@@ -606,9 +613,13 @@ suite('Bundler', () => {
       // duplication:
       //     <link rel="import" href="imports/simple-import.html">
       //     <link rel="import" href="imports/simple-import.html">
-      assert.equal(links.length, 1);
+      //     <link rel="import" href="imports/another-simple-import.html">
+      assert.equal(links.length, 2);
       assert.equal(
           dom5.getAttribute(links[0]!, 'href'), 'imports/simple-import.html');
+      assert.equal(
+          dom5.getAttribute(links[1]!, 'href'),
+          'imports/another-simple-import.html');
     });
   });
 
@@ -707,10 +718,12 @@ suite('Bundler', () => {
       const styles = dom5.queryAll(
           doc, matchers.styleMatcher, [], dom5.childNodesIncludeTemplate);
       assert.equal(links.length, 0);
-      assert.equal(styles.length, 3);
+      assert.equal(styles.length, 5);
       assert.match(dom5.getTextContent(styles[0]), /regular-style/);
       assert.match(dom5.getTextContent(styles[1]), /simple-style/);
       assert.match(dom5.getTextContent(styles[2]), /import-linked-style/);
+      assert.match(dom5.getTextContent(styles[3]), /simple-style/);
+      assert.match(dom5.getTextContent(styles[4]), /import-linked-style/);
 
       // Verify the inlined url() values in the stylesheet are not rewritten
       // to use the "imports/" prefix, since the stylesheet is inside a

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -173,7 +173,7 @@ suite('Bundler', () => {
       const expectedEntrypointsToDeps = new Map([
         [entrypoint, new Set([entrypoint])],
         [module1, new Set([abc, upcase])],
-        [module2, new Set([abc, upcase])],
+        [module2, new Set([abc, xyz, upcase])],
         [module3, new Set([def, xyz, upcase])],
       ]);
       chai.assert.deepEqual(

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -136,9 +136,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-external-modules.html');
-      const module1 = entrypoint + '>external-module:1';
-      const module2 = entrypoint + '>external-module:2';
-      const module3 = entrypoint + '>external-module:3';
+      const module1 = entrypoint + '>external-module:1:abc.js';
+      const module2 = entrypoint + '>external-module:2:abc.js';
+      const module3 = entrypoint + '>external-module:3:def.js';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -136,9 +136,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-external-modules.html');
-      const module1 = entrypoint + '>external-module-1';
-      const module2 = entrypoint + '>external-module-2';
-      const module3 = entrypoint + '>external-module-3';
+      const module1 = entrypoint + '>external-module:1';
+      const module2 = entrypoint + '>external-module:2';
+      const module3 = entrypoint + '>external-module:3';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');
@@ -162,9 +162,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-inline-modules.html');
-      const module1 = entrypoint + '>inline-module-1';
-      const module2 = entrypoint + '>inline-module-2';
-      const module3 = entrypoint + '>inline-module-3';
+      const module1 = entrypoint + '>inline-module:1';
+      const module2 = entrypoint + '>inline-module:2';
+      const module3 = entrypoint + '>inline-module:3';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -136,9 +136,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-external-modules.html');
-      const module1 = entrypoint + '>external-module-1>abc.js';
-      const module2 = entrypoint + '>external-module-2>abc.js';
-      const module3 = entrypoint + '>external-module-3>def.js';
+      const module1 = entrypoint + '>external#1>abc.js>es6-module';
+      const module2 = entrypoint + '>external#2>abc.js>es6-module';
+      const module3 = entrypoint + '>external#3>def.js>es6-module';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');
@@ -162,9 +162,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-inline-modules.html');
-      const module1 = entrypoint + '>inline-module-1.js';
-      const module2 = entrypoint + '>inline-module-2.js';
-      const module3 = entrypoint + '>inline-module-3.js';
+      const module1 = entrypoint + '>inline#1>es6-module';
+      const module2 = entrypoint + '>inline#2>es6-module';
+      const module3 = entrypoint + '>inline#3>es6-module';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -136,9 +136,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-external-modules.html');
-      const module1 = entrypoint + '>external-module:1:abc.js';
-      const module2 = entrypoint + '>external-module:2:abc.js';
-      const module3 = entrypoint + '>external-module:3:def.js';
+      const module1 = entrypoint + '>external-module-1>abc.js';
+      const module2 = entrypoint + '>external-module-2>abc.js';
+      const module3 = entrypoint + '>external-module-3>def.js';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');
@@ -162,9 +162,9 @@ suite('Bundler', () => {
         urlLoader: new FSUrlLoader('test/html/imports/es6-modules')
       });
       const entrypoint = resolve('multiple-inline-modules.html');
-      const module1 = entrypoint + '>inline-module:1';
-      const module2 = entrypoint + '>inline-module:2';
-      const module3 = entrypoint + '>inline-module:3';
+      const module1 = entrypoint + '>inline-module-1.js';
+      const module2 = entrypoint + '>inline-module-2.js';
+      const module3 = entrypoint + '>inline-module-3.js';
       const abc = resolve('abc.js');
       const def = resolve('def.js');
       const xyz = resolve('xyz.js');

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -104,7 +104,8 @@ suite('Bundler', () => {
       assert.isDefined(entrypoint1Doc);
       const entrypoint2Doc = documents.get(entrypoint2)!.ast;
       assert.isDefined(entrypoint2Doc);
-      const sharedDoc = documents.get(resolve('shared_bundle_1.html'))!.ast;
+      const sharedDoc =
+          documents.get(resolve('shards/shop_style_project/dep1.html'))!.ast;
       assert.isDefined(sharedDoc);
       const commonModule = domModulePredicate('common-module');
       const elOne = domModulePredicate('el-one');

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -104,8 +104,7 @@ suite('Bundler', () => {
       assert.isDefined(entrypoint1Doc);
       const entrypoint2Doc = documents.get(entrypoint2)!.ast;
       assert.isDefined(entrypoint2Doc);
-      const sharedDoc =
-          documents.get(resolve('shards/shop_style_project/dep1.html'))!.ast;
+      const sharedDoc = documents.get(resolve('shared_bundle_1.html'))!.ast;
       assert.isDefined(sharedDoc);
       const commonModule = domModulePredicate('common-module');
       const elOne = domModulePredicate('el-one');

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -31,6 +31,14 @@ export function ensureTrailingSlash<T>(href: T): T {
 }
 
 /**
+ * Parses the URL and returns the extname of the path.
+ */
+export function getFileExtension(url_: string): string {
+  const uri = Uri.parse(url_);
+  return path.extname(uri.path);
+}
+
+/**
  * Returns a WHATWG ResolvedURL for a filename on local filesystem.
  */
 export function getFileUrl(filename: string): ResolvedUrl {

--- a/test/html/default.html
+++ b/test/html/default.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="imports/regular-style.css">
   <link rel="import" href="imports/simple-import.html">
   <link rel="import" href="imports/simple-import.html">
+  <link rel="import" href="imports/another-simple-import.html">
   <title>Sample Build</title>
 </head>
 <body>

--- a/test/html/imports/another-simple-import.html
+++ b/test/html/imports/another-simple-import.html
@@ -1,0 +1,32 @@
+<!--
+    @license
+    Copyright (c) 2014 The Polymer Project Authors. All rights reserved.
+    This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+    The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+    The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+    Code distributed by Google as part of the polymer project is also
+    subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<dom-module id="my-other-element">
+  <!--
+    This comment exists to be stripped.
+-->
+  <link rel="import" type="css" href="simple-style.css">
+  <link rel="import" type="css" href="import-linked-style.css">
+  <template>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 630 630">
+      <rect x="0" y="0" width="630" height="630" fill="#3c790a" />
+      <path d="m212 497c11" />
+      <polygon />
+      <path />
+      <polygon/>
+      <path />
+    </svg>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'my-other-element'
+  });
+
+</script>

--- a/test/html/imports/es6-modules/abc.js
+++ b/test/html/imports/es6-modules/abc.js
@@ -1,0 +1,4 @@
+import { upcase } from './upcase.js';
+export const A = upcase('a');
+export const B = upcase('b');
+export const C = upcase('c');

--- a/test/html/imports/es6-modules/def.js
+++ b/test/html/imports/es6-modules/def.js
@@ -1,0 +1,5 @@
+import { X, Y, Z } from './xyz.js';
+const D = X + X;
+const E = Y + Y;
+const F = Z + Z;
+export { D, E, F }

--- a/test/html/imports/es6-modules/multiple-external-modules.html
+++ b/test/html/imports/es6-modules/multiple-external-modules.html
@@ -1,0 +1,3 @@
+<script type="module" src="abc.js"></script>
+<script type="module" src="abc.js"></script>
+<script type="module" src="def.js"></script>

--- a/test/html/imports/es6-modules/multiple-inline-modules.html
+++ b/test/html/imports/es6-modules/multiple-inline-modules.html
@@ -5,7 +5,8 @@
 
 <script type="module">
   import {B, C} from './abc.js';
-  console.log(B,C);
+  import {Y} from './xyz.js';
+  console.log(B,C,Y);
 </script>
 
 <script type="module">

--- a/test/html/imports/es6-modules/multiple-inline-modules.html
+++ b/test/html/imports/es6-modules/multiple-inline-modules.html
@@ -1,0 +1,14 @@
+<script type="module">
+  import {A, B} from './abc.js';
+  console.log(A,B);
+</script>
+
+<script type="module">
+  import {B, C} from './abc.js';
+  console.log(B,C);
+</script>
+
+<script type="module">
+  import {D,F} from './def.js';
+  console.log(D,F);
+</script>

--- a/test/html/imports/es6-modules/upcase.js
+++ b/test/html/imports/es6-modules/upcase.js
@@ -1,0 +1,3 @@
+export function upcase(str) {
+  return str.toUpperCase();
+}

--- a/test/html/imports/es6-modules/xyz.js
+++ b/test/html/imports/es6-modules/xyz.js
@@ -1,0 +1,4 @@
+import { upcase } from './upcase.js';
+export const X = upcase('x');
+export const Y = upcase('y');
+export const Z = upcase('z');


### PR DESCRIPTION
- [BREAKING] The `DepsIndex` type returned from `buildDepsIndex` has changed to a single map of entrypoints to dependencies.
- Added support for `<script type="module">` and bundling of ES6 modules by following `import` statements.  Dynamic `import()` statements are treated similarly to the `<link rel="lazy-import">` tag in that the import target implicitly defines a new entrypoint/bundle.
- Shared bundles containing only one file are named after the original file instead of having naming delegated to shared bundle URL mapper.
- [x] CHANGELOG.md has been updated
