### PR TITLE
Switched to FsUrlResolver from PackageUrlResolver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-<!-- ## Unreleased -->
+## Unreleased
+- Upgraded to use `polymer-analyzer` version `3.0.0-pre.17`.
+- Switched to `FsUrlResolver` from `PackageUrlResolver` as the default `UrlResolver` for bundling contexts.  This is because `PackageUrlResolver` is intended for component analysis, not application analysis.
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.0-pre.1 - 2018-03-07

--- a/src/test/bundler_test.ts
+++ b/src/test/bundler_test.ts
@@ -18,7 +18,7 @@ import * as chai from 'chai';
 import * as dom5 from 'dom5';
 import * as fs from 'fs';
 import * as parse5 from 'parse5';
-import {Analyzer, FsUrlLoader, PackageUrlResolver} from 'polymer-analyzer';
+import {Analyzer, FsUrlLoader, FsUrlResolver} from 'polymer-analyzer';
 
 import {Bundle, generateShellMergeStrategy} from '../bundle-manifest';
 import {Bundler, Options as BundlerOptions} from '../bundler';
@@ -47,14 +47,12 @@ suite('Bundler', () => {
   function getAnalyzer(opts?: any): Analyzer {
     if (!analyzer) {
       if (!opts || !opts.urlResolver) {
-        const urlResolver = new PackageUrlResolver({
-          packageDir: resolvePath('test/html'),
-        });
-        opts = Object.assign({}, opts || {}, {urlResolver: urlResolver});
+        const urlResolver = new FsUrlResolver(resolvePath('test/html'), );
+        opts = Object.assign({}, opts || {}, {urlResolver});
       }
       if (!opts || !opts.urlLoader) {
         const urlLoader = new FsUrlLoader(resolvePath('test/html'));
-        opts = Object.assign({}, opts || {}, {urlLoader: urlLoader});
+        opts = Object.assign({}, opts || {}, {urlLoader});
       }
       analyzer = new Analyzer(opts);
     }

--- a/src/test/deps-index_test.ts
+++ b/src/test/deps-index_test.ts
@@ -16,7 +16,7 @@
 /// <reference path="../../node_modules/@types/node/index.d.ts" />
 /// <reference path="../../node_modules/@types/mocha/index.d.ts" />
 import * as chai from 'chai';
-import {Analyzer, FsUrlLoader, PackageRelativeUrl, PackageUrlResolver, ResolvedUrl} from 'polymer-analyzer';
+import {Analyzer, FsUrlLoader, FsUrlResolver, PackageRelativeUrl, ResolvedUrl} from 'polymer-analyzer';
 
 import {buildDepsIndex} from '../deps-index';
 
@@ -46,9 +46,8 @@ suite('Bundler', () => {
 
     test('with 3 endpoints', async () => {
       analyzer = new Analyzer({
-        urlResolver: new PackageUrlResolver({
-          packageDir: 'test/html/shards/polymer_style_project',
-        }),
+        urlResolver:
+            new FsUrlResolver('test/html/shards/polymer_style_project'),
         urlLoader: new FsUrlLoader('test/html/shards/polymer_style_project'),
       });
       const common = resolve('common.html');
@@ -71,9 +70,7 @@ suite('Bundler', () => {
     // Deps index currently treats lazy imports as eager imports.
     test('with lazy imports', async () => {
       analyzer = new Analyzer({
-        urlResolver: new PackageUrlResolver({
-          packageDir: 'test/html/imports',
-        }),
+        urlResolver: new FsUrlResolver('test/html/imports'),
         urlLoader: new FsUrlLoader('test/html/imports')
       });
       const entrypoint = resolve('lazy-imports.html');
@@ -108,9 +105,7 @@ suite('Bundler', () => {
 
     test('when an entrypoint imports an entrypoint', async () => {
       analyzer = new Analyzer({
-        urlResolver: new PackageUrlResolver({
-          packageDir: 'test/html/imports',
-        }),
+        urlResolver: new FsUrlResolver('test/html/imports'),
         urlLoader: new FsUrlLoader('test/html/imports')
       });
       const entrypoint = resolve('eagerly-importing-a-fragment.html');

--- a/src/test/shards_test.ts
+++ b/src/test/shards_test.ts
@@ -17,7 +17,7 @@
 import * as chai from 'chai';
 import * as dom5 from 'dom5';
 import * as parse5 from 'parse5';
-import {Analyzer, FsUrlLoader, PackageRelativeUrl, PackageUrlResolver} from 'polymer-analyzer';
+import {Analyzer, FsUrlLoader, FsUrlResolver, PackageRelativeUrl} from 'polymer-analyzer';
 
 import {generateSharedDepsMergeStrategy, generateShellMergeStrategy} from '../bundle-manifest';
 import {Bundler, BundleResult} from '../bundler';
@@ -49,7 +49,7 @@ suite('Bundler', () => {
   function getAnalyzer(): Analyzer {
     if (!analyzer) {
       analyzer = new Analyzer({
-        urlResolver: new PackageUrlResolver({packageDir: 'test/html'}),
+        urlResolver: new FsUrlResolver('test/html'),
         urlLoader: new FsUrlLoader('test/html'),
       });
     }

--- a/src/test/sourcemap_test.ts
+++ b/src/test/sourcemap_test.ts
@@ -17,7 +17,7 @@
 import * as chai from 'chai';
 import * as dom5 from 'dom5';
 import * as path from 'path';
-import {Analyzer, FsUrlLoader, PackageRelativeUrl, PackageUrlResolver, ResolvedUrl} from 'polymer-analyzer';
+import {Analyzer, FsUrlLoader, FsUrlResolver, PackageRelativeUrl, ResolvedUrl} from 'polymer-analyzer';
 import {MappingItem, RawSourceMap, SourceMapConsumer} from 'source-map';
 
 import {Bundler} from '../bundler';
@@ -86,10 +86,8 @@ suite('Bundler', () => {
 
   const basePath = resolvePath('test/html/sourcemaps/');
   const urlLoader = new FsUrlLoader(basePath);
-  const analyzer = new Analyzer({
-    urlResolver: new PackageUrlResolver({packageDir: basePath}),
-    urlLoader: urlLoader
-  });
+  const analyzer = new Analyzer(
+      {urlResolver: new FsUrlResolver(basePath), urlLoader: urlLoader});
 
   suite('Sourcemaps', () => {
 


### PR DESCRIPTION
- Switched to `FsUrlResolver` from `PackageUrlResolver` as the default `UrlResolver` for bundling contexts.  This is because `PackageUrlResolver` is intended for component analysis, not application analysis.
- [x] CHANGELOG.md has been updated
