### PR TITLE
Use analyzers export features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - [BREAKING] The `--in-html` and `--out-html` arguments for `bin/polymer-bundler` are now `--in-file` and `--out-file` because input filetypes are no longer limited to HTML.
 - ES6 Module Bundling! Bundler can simultaneously process HTML imports and ES6 module imports, including inline `<script type="module">` scripts.
+- Fixed issue where `export * from 'x'` did not export identifiers from module `x`.
 <!-- Add new, unreleased changes here. -->
 
 ## 4.0.0-pre.2 - 2018-03-20

--- a/src/test/es6-module-bundling-scenarios_test.ts
+++ b/src/test/es6-module-bundling-scenarios_test.ts
@@ -36,6 +36,7 @@ suite('Es6 Module Bundling', () => {
       `,
       'c.js': `
         export const C = 'c';
+        export {C as default};
       `,
     });
     const aUrl = analyzer.resolveUrl('a.js')!;
@@ -45,7 +46,8 @@ suite('Es6 Module Bundling', () => {
     assert.deepEqual(documents.get(aUrl)!.content, heredoc`
       const C = 'c';
       var c = {
-        C: C
+        C: C,
+        default: C
       };
       const B = 'b';
       var b = {
@@ -58,7 +60,7 @@ suite('Es6 Module Bundling', () => {
         B: B,
         C: C
       };
-      export { a as $a, b as $b, c as $c, C, B, A, C as C$1, B as B$1, C as C$2 };`);
+      export { a as $a, b as $b, c as $c, C, B, A, C as C$1, B as B$1, C as C$2, C as $cDefault };`);
   });
 
   suite('rewriting import specifiers', () => {

--- a/src/test/es6-module-bundling-scenarios_test.ts
+++ b/src/test/es6-module-bundling-scenarios_test.ts
@@ -139,7 +139,7 @@ suite('Es6 Module Bundling', () => {
           honey: honey,
           beeSea: beeSea
         };
-        export { b$1 as $b, b as $bDefault, c as $c, sea$1 as $cDefault, honey, beeSea, boat };`);
+        export { b$1 as $b, c as $c, b as $bDefault, honey, beeSea, sea$1 as $cDefault, boat };`);
     });
   });
 


### PR DESCRIPTION
Bundler had its own `getModuleExportNames` function which scanned for export identifiers.  Analyzer provides these now, so I changed code to delegate to Analyzer to obtain them.

This seemed to address two related issues:

 1. Identifying a default export in a form other than `export default x` such as `export {x as default}` https://github.com/Polymer/polymer-bundler/issues/645 
 2. Exports in "export * from" statements don't populate export list of bundled module https://github.com/Polymer/polymer-bundler/issues/641

So that's nice.