### PR TITLE
Fixed explicit undefined checks while upgrading to analyzer 3.0.0-pre.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2295,9 +2295,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "3.0.0-pre.17",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.17.tgz",
-      "integrity": "sha512-iBNhCEFMAqiMKHdSlIEBpW9EM7j4tI5R0yRzLQ4//J1ZTvnoJCcXS81SZerG5BeSPITCTJweioutm30HwzhfiQ==",
+      "version": "3.0.0-pre.18",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-3.0.0-pre.18.tgz",
+      "integrity": "sha512-3tTtq/96tdJMkDL3TycD+gfTs0Z5I1DghjMRn6jU27e2De38VTVsFuHt36PmW+pVs1n7n5itwK0Py56Fsl3Eog==",
       "requires": {
         "@types/babel-generator": "6.25.1",
         "@types/babel-traverse": "6.25.3",
@@ -2329,7 +2329,7 @@
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
         "path-is-inside": "1.0.2",
-        "polymer-project-config": "3.10.0",
+        "polymer-project-config": "3.11.0",
         "resolve": "1.6.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
@@ -2454,9 +2454,9 @@
       }
     },
     "polymer-project-config": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.10.0.tgz",
-      "integrity": "sha512-+vrx5aAZM3rpViqnYhTX1bIpXXTlGpiAGZEsk7WzN6EqSMQPI5eYRw4XD1kmjo1W6GShIhPfvhh+Ik/pywGGkw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.11.0.tgz",
+      "integrity": "sha512-KEu2nMeSZCVvU5mItSaIY9JW6fnyU/L0Cn/OScwiGPMGbqLm7dH5mnWTLNkSOGB83cBp6NVphoDNOaS8QA4Wkw==",
       "requires": {
         "@types/node": "6.0.103",
         "jsonschema": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "magic-string": "^0.22.4",
     "mkdirp": "^0.5.1",
     "parse5": "^2.2.2",
-    "polymer-analyzer": "^3.0.0-pre.17",
+    "polymer-analyzer": "^3.0.0-pre.18",
     "rollup": "^0.56.1",
     "source-map": "^0.5.6",
     "vscode-uri": "^1.0.1"

--- a/src/deps-index.ts
+++ b/src/deps-index.ts
@@ -164,14 +164,15 @@ function getDependencies(
     const htmlScripts =
         [...document.getFeatures({kind: 'html-script', ...getFeaturesOptions})]
             .filter(
-                (i) => (i.document.parsedDocument as JavaScriptDocument)
-                           .parsedAsSourceType === 'module');
+                (i) => i.document !== undefined &&
+                    (i.document.parsedDocument as JavaScriptDocument)
+                            .parsedAsSourceType === 'module');
     for (const htmlScript of htmlScripts) {
       const relativeUrl =
-          analyzer.urlResolver.relative(document.url, htmlScript.document.url);
+          analyzer.urlResolver.relative(document.url, htmlScript.document!.url);
       moduleScriptImports.set(
           `external#${++externalModuleCount}>${relativeUrl}>es6-module`,
-          htmlScript.document);
+          htmlScript.document!);
     }
   }
 
@@ -191,6 +192,9 @@ function getDependencies(
   function _getImportDependencies(
       imports: Iterable<Import>, viaEager: boolean) {
     for (const imprt of imports) {
+      if (imprt.document === undefined) {
+        continue;
+      }
       const importUrl = imprt.document.url;
       if (imprt.lazy) {
         lazyImports.add(importUrl);

--- a/src/es6-rewriter.ts
+++ b/src/es6-rewriter.ts
@@ -99,7 +99,7 @@ export class Es6Rewriter {
                 for (const jsImport of jsImports) {
                   const source = jsImport.astNode && jsImport.astNode.source &&
                       jsImport.astNode.source.value;
-                  if (source) {
+                  if (source && jsImport.document !== undefined) {
                     resolutions.set(source, jsImport.document.url);
                   }
                 }

--- a/src/html-bundler.ts
+++ b/src/html-bundler.ts
@@ -200,20 +200,17 @@ export class HtmlBundler {
     const existingImports = [
       ...this.document.getFeatures(
           {kind: 'html-import', noLazyImports: true, imported: false})
-    ].filter((i) => !i.lazy);
+    ].filter((i) => !i.lazy && i.document !== undefined);
     const existingImportDependencies = new Map<ResolvedUrl, ResolvedUrl[]>();
-    for (const existingImport of existingImports) {
-      if (existingImport.document === undefined) {
-        continue;
-      }
-      const transitiveImports =
-          [...existingImport.document.getFeatures({
+    for (const {url, document} of existingImports) {
+      existingImportDependencies.set(
+          url,
+          [...document!.getFeatures({
             kind: 'html-import',
             imported: true,
             noLazyImports: true,
           })].filter((i) => i.lazy === false && i.document !== undefined)
-              .map((i) => i.document!.url);
-      existingImportDependencies.set(existingImport.url, transitiveImports);
+              .map((i) => i.document!.url));
     }
     // Every HTML file in the bundle is a candidate for injection into the
     // document.


### PR DESCRIPTION
Upgraded to analyzer 3.0.0-pre.18 and there were `tsc` errors around explicit undefined checks.  Fixed these.  Refactored https://github.com/Polymer/polymer-bundler/compare/upgrade-to-analyzer-3.0.0-pre.18?expand=1#diff-2fc6fb048016c523bd896c8e6632f8d1R204 for readability.