### PR TITLE
Prepare release 4.0.0 pre.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new, unreleased changes here. -->
+## 4.0.0-pre.3 - 2018-03-28
 - [BREAKING] The `--in-html` and `--out-html` arguments for `bin/polymer-bundler` are now `--in-file` and `--out-file` because input filetypes are no longer limited to HTML.
 - ES6 Module Bundling! Bundler can simultaneously process HTML imports and ES6 module imports, including inline `<script type="module">` scripts.
 - Fixed issue where `export * from 'x'` did not export identifiers from module `x`.
-<!-- Add new, unreleased changes here. -->
 
 ## 4.0.0-pre.2 - 2018-03-20
 - Upgraded to use `polymer-analyzer` version `3.0.0-pre.17`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -925,7 +925,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "debug": {
@@ -1070,9 +1070,9 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.41",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.41.tgz",
-      "integrity": "sha512-MYK02wXfwTMie5TEJWPolgOsXEmz7wKCQaGzgmRjZOoV6VLG8I5dSv2bn6AOClXhK64gnSQTQ9W9MKvx87J4gw==",
+      "version": "0.10.42",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
+      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -1087,7 +1087,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-symbol": "3.1.1"
       }
     },
@@ -1098,7 +1098,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -1112,7 +1112,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -1125,7 +1125,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "es6-weak-map": {
@@ -1135,7 +1135,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41",
+        "es5-ext": "0.10.42",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -1252,7 +1252,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.41"
+        "es5-ext": "0.10.42"
       }
     },
     "exit-hook": {
@@ -2329,7 +2329,7 @@
         "minimatch": "3.0.4",
         "parse5": "4.0.0",
         "path-is-inside": "1.0.2",
-        "polymer-project-config": "3.11.0",
+        "polymer-project-config": "3.11.1",
         "resolve": "1.6.0",
         "shady-css-parser": "0.1.0",
         "stable": "0.1.6",
@@ -2454,9 +2454,9 @@
       }
     },
     "polymer-project-config": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.11.0.tgz",
-      "integrity": "sha512-KEu2nMeSZCVvU5mItSaIY9JW6fnyU/L0Cn/OScwiGPMGbqLm7dH5mnWTLNkSOGB83cBp6NVphoDNOaS8QA4Wkw==",
+      "version": "3.11.1",
+      "resolved": "https://registry.npmjs.org/polymer-project-config/-/polymer-project-config-3.11.1.tgz",
+      "integrity": "sha512-sz5ooBVkoIPUj+CvPwWcrs5OkdwzBAcD8z+KMM9R1IHdqkj4B7mu2qAk8166lr5edIJJ0HoEQxa3Dx10YqJWdw==",
       "requires": {
         "@types/node": "6.0.103",
         "jsonschema": "1.2.2",


### PR DESCRIPTION
## 4.0.0-pre.3 - 2018-03-28
 - [BREAKING] The `--in-html` and `--out-html` arguments for `bin/polymer-bundler` are now `--in-file` and `--out-file` because input filetypes are no longer limited to HTML.
 - ES6 Module Bundling! Bundler can simultaneously process HTML imports and ES6 module imports, including inline `<script type="module">` scripts.
 - Fixed issue where `export * from 'x'` did not export identifiers from module `x`.
 - [x] CHANGELOG.md has been updated
